### PR TITLE
Fix stew import

### DIFF
--- a/faststreams/output_stream.nim
+++ b/faststreams/output_stream.nim
@@ -1,5 +1,5 @@
 import
-  deques, ranges/ptr_arith, std_shims/strings
+  deques, ranges/ptr_arith, stew/strings
 
 type
   OutputStreamVTable = tuple


### PR DESCRIPTION
Some [changes to the directory structure of stew](https://github.com/status-im/nim-stew/commit/0a8e95408f286873244ee40215e4907f62d37ee1) seem to be [causing the AppVeyor CI for the Nim compiler to fail when it hits the tests for nim-chronicle.](https://ci.appveyor.com/project/dom96/nim/builds/25790889/job/u36wih34lt82kdor)

This should (probably) fix it.