### PR TITLE
Don't import/export chronos by default

### DIFF
--- a/faststreams.nimble
+++ b/faststreams.nimble
@@ -1,7 +1,7 @@
 mode = ScriptMode.Verbose
 
 packageName   = "faststreams"
-version       = "0.2.0"
+version       = "0.3.0"
 author        = "Status Research & Development GmbH"
 description   = "Nearly zero-overhead input/output streams for Nim"
 license       = "Apache License 2.0"
@@ -21,7 +21,12 @@ proc test(env, path: string) =
     lang = getEnv"TEST_LANG"
 
   exec "nim " & lang & " " & env &
-    " -r --hints:off --skipParentCfg " & path
+    " -d:async_backend=none -r --hints:off --skipParentCfg " & path
+  exec "nim " & lang & " " & env &
+    " -d:async_backend=chronos -r --hints:off --skipParentCfg " & path
+  # TODO std backend is broken / untested
+  # exec "nim " & lang & " " & env &
+  #  " -d:async_backend=chronos -r --hints:off --skipParentCfg " & path
 
 task test, "Run all tests":
   test "-d:debug   --threads:on", "tests/all_tests"

--- a/faststreams/async_backend.nim
+++ b/faststreams/async_backend.nim
@@ -1,14 +1,25 @@
 const
-  faststreams_async_backend {.strdefine.} = "chronos"
+  # To compile with async support, use `-d:async_backend=chronos|asyncdispatch`
+  async_backend {.strdefine.} = "none"
+
+const
+  faststreams_async_backend {.strdefine.} = ""
+
+when faststreams_async_backend != "":
+  {.fatal: "use `-d:async_backend` instead".}
 
 type
   CloseBehavior* = enum
     waitAsyncClose
     dontWaitAsyncClose
 
-const debugHelpers* = defined(debugHelpers)
+const
+  debugHelpers* = defined(debugHelpers)
+  fsAsyncSupport* = async_backend != "none"
 
-when faststreams_async_backend == "chronos":
+when async_backend == "none":
+  discard
+elif async_backend == "chronos":
   import
     chronos
 
@@ -18,10 +29,10 @@ when faststreams_async_backend == "chronos":
   template fsAwait*(f: Future): untyped =
     await f
 
-elif faststreams_async_backend in ["std", "asyncdispatch"]:
+elif async_backend in ["std", "asyncdispatch"]:
   import
     std/asyncdispatch
-  
+
   export
     asyncdispatch
 
@@ -36,7 +47,7 @@ elif faststreams_async_backend in ["std", "asyncdispatch"]:
   type Duration* = int
 
 else:
-  {.fatal: "Unrecognized network backend: " & faststreams_async_backend.}
+  {.fatal: "Unrecognized network backend: " & async_backend.}
 
 when defined(danger):
   template fsAssert*(x) = discard

--- a/faststreams/buffers.nim
+++ b/faststreams/buffers.nim
@@ -22,8 +22,9 @@ type
     maxBufferedBytes*: Natural
 
     queue*: Deque[PageRef]
-    waitingReader*: Future[void]
-    waitingWriter*: Future[void]
+    when fsAsyncSupport:
+      waitingReader*: Future[void]
+      waitingWriter*: Future[void]
 
     eofReached*: bool
     fauxEofPos*: Natural

--- a/faststreams/multisync.nim
+++ b/faststreams/multisync.nim
@@ -1,35 +1,40 @@
 import
-  stew/shims/macros,
-  async_backend, inputs, outputs
+  async_backend
 
 export
   async_backend
 
-macro fsMultiSync*(body: untyped) =
-  # We will produce an identical copy of the annotated proc,
-  # but taking async parameters and having the async pragma.
-  var
-    asyncProcBody = copy body
-    asyncProcParams = asyncProcBody[3]
+when fsAsyncSupport:
+  import
+    stew/shims/macros,
+    "."/[inputs, outputs]
 
-  asyncProcBody.addPragma(bindSym"async")
+  macro fsMultiSync*(body: untyped) =
+    # We will produce an identical copy of the annotated proc,
+    # but taking async parameters and having the async pragma.
+    var
+      asyncProcBody = copy body
+      asyncProcParams = asyncProcBody[3]
 
-  # The return types becomes Future[T]
-  if asyncProcParams[0].kind == nnkEmpty:
-    asyncProcParams[0] = newTree(nnkBracketExpr, bindSym"Future", ident"void")
-  else:
-    asyncProcParams[0] = newTree(nnkBracketExpr, bindSym"Future", asyncProcParams[0])
+    asyncProcBody.addPragma(bindSym"async")
 
-  # We replace all stream inputs with their async counterparts
-  for i in 1 ..< asyncProcParams.len:
-    let paramsDef = asyncProcParams[i]
-    let typ = paramsDef[^2]
-    if eqIdent(typ, "InputStream"):
-      paramsDef[^2] = bindSym "AsyncInputStream"
-    elif eqIdent(typ, "OutputStream"):
-      paramsDef[^2] = bindSym "AsyncOutputStream"
+    # The return types becomes Future[T]
+    if asyncProcParams[0].kind == nnkEmpty:
+      asyncProcParams[0] = newTree(nnkBracketExpr, bindSym"Future", ident"void")
+    else:
+      asyncProcParams[0] = newTree(nnkBracketExpr, bindSym"Future", asyncProcParams[0])
 
-  result = newStmtList(body, asyncProcBody)
-  when defined(debugSupportAsync):
-    echo result.repr
+    # We replace all stream inputs with their async counterparts
+    for i in 1 ..< asyncProcParams.len:
+      let paramsDef = asyncProcParams[i]
+      let typ = paramsDef[^2]
+      if eqIdent(typ, "InputStream"):
+        paramsDef[^2] = bindSym "AsyncInputStream"
+      elif eqIdent(typ, "OutputStream"):
+        paramsDef[^2] = bindSym "AsyncOutputStream"
 
+    result = newStmtList(body, asyncProcBody)
+    when defined(debugSupportAsync):
+      echo result.repr
+else:
+  macro fsMultiSync*(body: untyped) = body

--- a/faststreams/pipelines.nim
+++ b/faststreams/pipelines.nim
@@ -1,337 +1,341 @@
 import
-  macros,
-  inputs, outputs, buffers, async_backend
+  "."/[inputs, outputs, async_backend]
 
 export
   inputs, outputs, async_backend
 
-type
-  Pipe* = ref object
-    # TODO: Make these stream handles
-    input*: AsyncInputStream
-    output*: AsyncOutputStream
-    buffers*: PageBuffers
+when fsAsyncSupport:
+  import
+    std/macros,
+    ./buffers
 
-template enterWait(fut: var Future, context: static string) =
-  let wait = newFuture[void](context)
-  fut = wait
-  try: fsAwait wait
-  finally: fut = nil
+  type
+    Pipe* = ref object
+      # TODO: Make these stream handles
+      input*: AsyncInputStream
+      output*: AsyncOutputStream
+      buffers*: PageBuffers
 
-template awake(fp: Future) =
-  let f = fp
-  if f != nil and not finished(f):
-    complete f
+  template enterWait(fut: var Future, context: static string) =
+    let wait = newFuture[void](context)
+    fut = wait
+    try: fsAwait wait
+    finally: fut = nil
 
-proc pipeRead(s: LayeredInputStream,
-              dst: pointer, dstLen: Natural): Future[Natural] {.async.} =
-  let buffers = s.buffers
-  if buffers.eofReached: return 0
+  template awake(fp: Future) =
+    let f = fp
+    if f != nil and not finished(f):
+      complete f
 
-  var
-    bytesInBuffersAtStart = buffers.totalBufferedBytes
-    minBytesExpected = max(1, dstLen)
-    bytesInBuffersNow = bytesInBuffersAtStart
+  proc pipeRead(s: LayeredInputStream,
+                dst: pointer, dstLen: Natural): Future[Natural] {.async.} =
+    let buffers = s.buffers
+    if buffers.eofReached: return 0
 
-  while bytesInBuffersNow < minBytesExpected:
+    var
+      bytesInBuffersAtStart = buffers.totalBufferedBytes
+      minBytesExpected = max(1, dstLen)
+      bytesInBuffersNow = bytesInBuffersAtStart
+
+    while bytesInBuffersNow < minBytesExpected:
+      awake buffers.waitingWriter
+      buffers.waitingReader.enterWait "waiting for writer to buffer more data"
+
+      bytesInBuffersNow = buffers.totalBufferedBytes
+      if buffers.eofReached:
+        return bytesInBuffersNow - bytesInBuffersAtStart
+
+    if dst != nil:
+      let drained {.used.} = drainBuffersInto(s, cast[ptr byte](dst), dstLen)
+      fsAssert drained == dstLen
+
     awake buffers.waitingWriter
-    buffers.waitingReader.enterWait "waiting for writer to buffer more data"
 
-    bytesInBuffersNow = buffers.totalBufferedBytes
-    if buffers.eofReached:
-      return bytesInBuffersNow - bytesInBuffersAtStart
+    return bytesInBuffersNow - bytesInBuffersAtStart
 
-  if dst != nil:
-    let drained {.used.} = drainBuffersInto(s, cast[ptr byte](dst), dstLen)
-    fsAssert drained == dstLen
+  proc pipeWrite(s: LayeredOutputStream, src: pointer, srcLen: Natural) {.async.} =
+    let buffers = s.buffers
+    while buffers.canAcceptWrite(srcLen) == false:
+      buffers.waitingWriter.enterWait "waiting for reader to drain the buffers"
 
-  awake buffers.waitingWriter
+    if src != nil:
+      buffers.appendUnbufferedWrite(src, srcLen)
 
-  return bytesInBuffersNow - bytesInBuffersAtStart
+    awake buffers.waitingReader
+    describeBuffers "pipeWrite", buffers
 
-proc pipeWrite(s: LayeredOutputStream, src: pointer, srcLen: Natural) {.async.} =
-  let buffers = s.buffers
-  while buffers.canAcceptWrite(srcLen) == false:
-    buffers.waitingWriter.enterWait "waiting for reader to drain the buffers"
+  template completedFuture(name: static string): untyped =
+    let fut = newFuture[void](name)
+    complete fut
+    fut
 
-  if src != nil:
-    buffers.appendUnbufferedWrite(src, srcLen)
-
-  awake buffers.waitingReader
-  describeBuffers "pipeWrite", buffers
-
-template completedFuture(name: static string): untyped =
-  let fut = newFuture[void](name)
-  complete fut
-  fut
-
-let pipeInputVTable = InputStreamVTable(
-  readSync: proc (s: InputStream, dst: pointer, dstLen: Natural): Natural
-                 {.nimcall, gcsafe, raises: [IOError, Defect].} =
-    fsTranslateErrors "Failed to read from pipe":
-      let ls = LayeredInputStream(s)
-      fsAssert ls.allowWaitFor
-      return waitFor pipeRead(ls, dst, dstLen)
-  ,
-  readAsync: proc (s: InputStream, dst: pointer, dstLen: Natural): Future[Natural]
+  let pipeInputVTable = InputStreamVTable(
+    readSync: proc (s: InputStream, dst: pointer, dstLen: Natural): Natural
                   {.nimcall, gcsafe, raises: [IOError, Defect].} =
-    fsTranslateErrors "Unexpected error from the async macro":
-      let ls = LayeredInputStream(s)
-      return pipeRead(ls, dst, dstLen)
-  ,
-  getLenSync: proc (s: InputStream): Option[Natural]
-                   {.nimcall, gcsafe, raises: [IOError, Defect].} =
-    let source = LayeredInputStream(s).source
-    if source != nil:
-      return source.len
-  ,
-  closeSync: proc (s: InputStream)
-                  {.nimcall, gcsafe, raises: [IOError, Defect].} =
-    let source = LayeredInputStream(s).source
-    if source != nil:
-      close source
-  ,
-  closeAsync: proc (s: InputStream): Future[void]
-                   {.nimcall, gcsafe, raises: [IOError, Defect].} =
-    fsTranslateErrors "Unexpected error from the async macro":
+      fsTranslateErrors "Failed to read from pipe":
+        let ls = LayeredInputStream(s)
+        fsAssert ls.allowWaitFor
+        return waitFor pipeRead(ls, dst, dstLen)
+    ,
+    readAsync: proc (s: InputStream, dst: pointer, dstLen: Natural): Future[Natural]
+                    {.nimcall, gcsafe, raises: [IOError, Defect].} =
+      fsTranslateErrors "Unexpected error from the async macro":
+        let ls = LayeredInputStream(s)
+        return pipeRead(ls, dst, dstLen)
+    ,
+    getLenSync: proc (s: InputStream): Option[Natural]
+                    {.nimcall, gcsafe, raises: [IOError, Defect].} =
       let source = LayeredInputStream(s).source
       if source != nil:
-        return closeAsync(Async source)
-      else:
-        return completedFuture("pipeInput.closeAsync")
-)
+        return source.len
+    ,
+    closeSync: proc (s: InputStream)
+                    {.nimcall, gcsafe, raises: [IOError, Defect].} =
+      let source = LayeredInputStream(s).source
+      if source != nil:
+        close source
+    ,
+    closeAsync: proc (s: InputStream): Future[void]
+                    {.nimcall, gcsafe, raises: [IOError, Defect].} =
+      fsTranslateErrors "Unexpected error from the async macro":
+        let source = LayeredInputStream(s).source
+        if source != nil:
+          return closeAsync(Async source)
+        else:
+          return completedFuture("pipeInput.closeAsync")
+  )
 
-let pipeOutputVTable = OutputStreamVTable(
-  writeSync: proc (s: OutputStream, src: pointer, srcLen: Natural)
-                  {.nimcall, gcsafe, raises: [IOError, Defect].} =
-    fsTranslateErrors "Failed to write all bytes to pipe":
-      var ls = LayeredOutputStream(s)
-      fsAssert ls.allowWaitFor
-      waitFor pipeWrite(ls, src, srcLen)
-  ,
-  writeAsync: proc (s: OutputStream, src: pointer, srcLen: Natural): Future[void]
-                   {.nimcall, gcsafe, raises: [IOError, Defect].} =
-    # TODO: The async macro is raising exceptions even when
-    #       merely forwarding a future:
-    fsTranslateErrors "Unexpected error from the async macro":
-      return pipeWrite(LayeredOutputStream s, src, srcLen)
-  ,
-  flushSync: proc (s: OutputStream)
-                  {.nimcall, gcsafe, raises: [IOError, Defect].} =
-    let destination = LayeredOutputStream(s).destination
-    if destination != nil:
-      flush destination
-  ,
-  flushAsync: proc (s: OutputStream): Future[void]
-                   {.nimcall, gcsafe, raises: [IOError, Defect].} =
-    fsTranslateErrors "Unexpected error from the async macro":
+  let pipeOutputVTable = OutputStreamVTable(
+    writeSync: proc (s: OutputStream, src: pointer, srcLen: Natural)
+                    {.nimcall, gcsafe, raises: [IOError, Defect].} =
+      fsTranslateErrors "Failed to write all bytes to pipe":
+        var ls = LayeredOutputStream(s)
+        fsAssert ls.allowWaitFor
+        waitFor pipeWrite(ls, src, srcLen)
+    ,
+    writeAsync: proc (s: OutputStream, src: pointer, srcLen: Natural): Future[void]
+                    {.nimcall, gcsafe, raises: [IOError, Defect].} =
+      # TODO: The async macro is raising exceptions even when
+      #       merely forwarding a future:
+      fsTranslateErrors "Unexpected error from the async macro":
+        return pipeWrite(LayeredOutputStream s, src, srcLen)
+    ,
+    flushSync: proc (s: OutputStream)
+                    {.nimcall, gcsafe, raises: [IOError, Defect].} =
       let destination = LayeredOutputStream(s).destination
       if destination != nil:
-        return flushAsync(Async destination)
-      else:
-        return completedFuture("pipeOutput.flushAsync")
-  ,
-  closeSync: proc (s: OutputStream)
-                  {.nimcall, gcsafe, raises: [IOError, Defect].} =
+        flush destination
+    ,
+    flushAsync: proc (s: OutputStream): Future[void]
+                    {.nimcall, gcsafe, raises: [IOError, Defect].} =
+      fsTranslateErrors "Unexpected error from the async macro":
+        let destination = LayeredOutputStream(s).destination
+        if destination != nil:
+          return flushAsync(Async destination)
+        else:
+          return completedFuture("pipeOutput.flushAsync")
+    ,
+    closeSync: proc (s: OutputStream)
+                    {.nimcall, gcsafe, raises: [IOError, Defect].} =
 
-    s.buffers.eofReached = true
+      s.buffers.eofReached = true
 
-    fsTranslateErrors "Unexpected error from Future.complete":
-      awake s.buffers.waitingReader
+      fsTranslateErrors "Unexpected error from Future.complete":
+        awake s.buffers.waitingReader
 
-    let destination = LayeredOutputStream(s).destination
-    if destination != nil:
-      close destination
-  ,
-  closeAsync: proc (s: OutputStream): Future[void]
-                   {.nimcall, gcsafe, raises: [IOError, Defect].} =
-    s.buffers.eofReached = true
-
-    fsTranslateErrors "Unexpected error from Future.complete":
-      awake s.buffers.waitingReader
-
-    fsTranslateErrors "Unexpected error from the async macro":
       let destination = LayeredOutputStream(s).destination
       if destination != nil:
-        return closeAsync(Async destination)
-      else:
-        return completedFuture("pipeOutput.closeAsync")
-)
+        close destination
+    ,
+    closeAsync: proc (s: OutputStream): Future[void]
+                    {.nimcall, gcsafe, raises: [IOError, Defect].} =
+      s.buffers.eofReached = true
 
-func pipeInput*(source: InputStream,
-                pageSize = defaultPageSize,
-                allowWaitFor = false): AsyncInputStream =
-  fsAssert pageSize > 0
+      fsTranslateErrors "Unexpected error from Future.complete":
+        awake s.buffers.waitingReader
 
-  AsyncInputStream LayeredInputStream(
-    vtable: vtableAddr pipeInputVTable,
-    buffers: initPageBuffers pageSize,
-    allowWaitFor: allowWaitFor,
-    source: source)
+      fsTranslateErrors "Unexpected error from the async macro":
+        let destination = LayeredOutputStream(s).destination
+        if destination != nil:
+          return closeAsync(Async destination)
+        else:
+          return completedFuture("pipeOutput.closeAsync")
+  )
 
-func pipeInput*(buffers: PageBuffers,
-                allowWaitFor = false,
-                source: InputStream = nil): AsyncInputStream =
-  var spanEndPos = Natural 0
-  var span = if buffers.len == 0: default(PageSpan)
-             else: buffers.obtainReadableSpan(spanEndPos)
+  func pipeInput*(source: InputStream,
+                  pageSize = defaultPageSize,
+                  allowWaitFor = false): AsyncInputStream =
+    fsAssert pageSize > 0
 
-  AsyncInputStream LayeredInputStream(
-    vtable: vtableAddr pipeInputVTable,
-    buffers: buffers,
-    span: span,
-    spanEndPos: span.len,
-    allowWaitFor: allowWaitFor,
-    source: source)
+    AsyncInputStream LayeredInputStream(
+      vtable: vtableAddr pipeInputVTable,
+      buffers: initPageBuffers pageSize,
+      allowWaitFor: allowWaitFor,
+      source: source)
 
-proc pipeOutput*(destination: OutputStream,
-                 pageSize = defaultPageSize,
-                 maxBufferedBytes = defaultPageSize * 4,
-                 allowWaitFor = false): AsyncOutputStream =
-  fsAssert pageSize > 0
+  func pipeInput*(buffers: PageBuffers,
+                  allowWaitFor = false,
+                  source: InputStream = nil): AsyncInputStream =
+    var spanEndPos = Natural 0
+    var span = if buffers.len == 0: default(PageSpan)
+              else: buffers.obtainReadableSpan(spanEndPos)
 
-  var
-    buffers = initPageBuffers pageSize
-    span = buffers.getWritableSpan()
+    AsyncInputStream LayeredInputStream(
+      vtable: vtableAddr pipeInputVTable,
+      buffers: buffers,
+      span: span,
+      spanEndPos: span.len,
+      allowWaitFor: allowWaitFor,
+      source: source)
 
-  AsyncOutputStream LayeredOutputStream(
-    vtable: vtableAddr pipeOutputVTable,
-    buffers: buffers,
-    span: span,
-    spanEndPos: span.len,
-    allowWaitFor: allowWaitFor,
-    destination: destination)
+  proc pipeOutput*(destination: OutputStream,
+                  pageSize = defaultPageSize,
+                  maxBufferedBytes = defaultPageSize * 4,
+                  allowWaitFor = false): AsyncOutputStream =
+    fsAssert pageSize > 0
 
-proc pipeOutput*(buffers: PageBuffers,
-                 allowWaitFor = false,
-                 destination: OutputStream = nil): AsyncOutputStream =
-  var span = buffers.getWritableSpan()
-
-  AsyncOutputStream LayeredOutputStream(
-    vtable: vtableAddr pipeOutputVTable,
-    buffers: buffers,
-    span: span,
-    # TODO What if the buffers are partially populated?
-    #      Should we adjust the spanEndPos? This would
-    #      need the old buffers.totalBytesWritten var.
-    spanEndPos: span.len,
-    allowWaitFor: allowWaitFor,
-    destination: destination)
-
-func asyncPipe*(pageSize = defaultPageSize,
-                maxBufferedBytes = defaultPageSize * 4): Pipe =
-  fsAssert pageSize > 0
-  Pipe(buffers: initPageBuffers(pageSize, maxBufferedBytes))
-
-func initReader*(pipe: Pipe): AsyncInputStream =
-  result = pipeInput(pipe.buffers)
-  pipe.input = result
-
-func initWriter*(pipe: Pipe): AsyncOutputStream =
-  result = pipeOutput(pipe.buffers)
-  pipe.output = result
-
-proc exchangeBuffersAfterPipilineStep(input: InputStream, output: OutputStream) =
-  let formerInputBuffers = input.buffers
-  let formerOutputBuffers = output.getBuffers
-
-  input.resetBuffers formerOutputBuffers
-  output.recycleBuffers formerInputBuffers
-
-macro executePipeline*(start: InputStream, steps: varargs[untyped]): untyped =
-  result = newTree(nnkStmtListExpr)
-
-  var
-    inputVal = start
-    outputVal = newCall(bindSym"memoryOutput")
-
-    inputVar = genSym(nskVar, "input")
-    outputVar = genSym(nskVar, "output")
-
-    step0 = steps[0]
-
-  result.add quote do:
     var
-      `inputVar` = `inputVal`
-      `outputVar` = OutputStream `outputVal`
+      buffers = initPageBuffers pageSize
+      span = buffers.getWritableSpan()
 
-    `step0`(`inputVar`, `outputVar`)
+    AsyncOutputStream LayeredOutputStream(
+      vtable: vtableAddr pipeOutputVTable,
+      buffers: buffers,
+      span: span,
+      spanEndPos: span.len,
+      allowWaitFor: allowWaitFor,
+      destination: destination)
 
-  if steps.len > 2:
-    let step1 = steps[1]
+  proc pipeOutput*(buffers: PageBuffers,
+                  allowWaitFor = false,
+                  destination: OutputStream = nil): AsyncOutputStream =
+    var span = buffers.getWritableSpan()
+
+    AsyncOutputStream LayeredOutputStream(
+      vtable: vtableAddr pipeOutputVTable,
+      buffers: buffers,
+      span: span,
+      # TODO What if the buffers are partially populated?
+      #      Should we adjust the spanEndPos? This would
+      #      need the old buffers.totalBytesWritten var.
+      spanEndPos: span.len,
+      allowWaitFor: allowWaitFor,
+      destination: destination)
+
+  func asyncPipe*(pageSize = defaultPageSize,
+                  maxBufferedBytes = defaultPageSize * 4): Pipe =
+    fsAssert pageSize > 0
+    Pipe(buffers: initPageBuffers(pageSize, maxBufferedBytes))
+
+  func initReader*(pipe: Pipe): AsyncInputStream =
+    result = pipeInput(pipe.buffers)
+    pipe.input = result
+
+  func initWriter*(pipe: Pipe): AsyncOutputStream =
+    result = pipeOutput(pipe.buffers)
+    pipe.output = result
+
+  proc exchangeBuffersAfterPipilineStep(input: InputStream, output: OutputStream) =
+    let formerInputBuffers = input.buffers
+    let formerOutputBuffers = output.getBuffers
+
+    input.resetBuffers formerOutputBuffers
+    output.recycleBuffers formerInputBuffers
+
+  macro executePipeline*(start: InputStream, steps: varargs[untyped]): untyped =
+    result = newTree(nnkStmtListExpr)
+
+    var
+      inputVal = start
+      outputVal = newCall(bindSym"memoryOutput")
+
+      inputVar = genSym(nskVar, "input")
+      outputVar = genSym(nskVar, "output")
+
+      step0 = steps[0]
+
     result.add quote do:
-      let formerInputBuffers = `inputVar`.buffers
-      `inputVar` = memoryInput(getBuffers `outputVar`)
-      recycleBuffers(`outputVar`, formerInputBuffers)
-      `step1`(`inputVar`, `outputVar`)
+      var
+        `inputVar` = `inputVal`
+        `outputVar` = OutputStream `outputVal`
 
-  for i in 2 .. steps.len - 2:
-    let step = steps[i]
-    result.add quote do:
-      exchangeBuffersAfterPipilineStep(`inputVar`, `outputVar`)
-      `step`(`inputVar`, `outputVar`)
+      `step0`(`inputVar`, `outputVar`)
 
-  var closingCall = steps[^1]
-  closingCall.insert(1, outputVar)
-  result.add closingCall
+    if steps.len > 2:
+      let step1 = steps[1]
+      result.add quote do:
+        let formerInputBuffers = `inputVar`.buffers
+        `inputVar` = memoryInput(getBuffers `outputVar`)
+        recycleBuffers(`outputVar`, formerInputBuffers)
+        `step1`(`inputVar`, `outputVar`)
 
-  if defined(debugMacros) or defined(debugPipelines):
-    echo result.repr
+    for i in 2 .. steps.len - 2:
+      let step = steps[i]
+      result.add quote do:
+        exchangeBuffersAfterPipilineStep(`inputVar`, `outputVar`)
+        `step`(`inputVar`, `outputVar`)
 
-macro executePipeline*(start: AsyncInputStream, steps: varargs[untyped]): untyped =
-  var
-    stream = ident "stream"
-    pipelineSteps = ident "pipelineSteps"
-    pipelineBody = newTree(nnkStmtList)
+    var closingCall = steps[^1]
+    closingCall.insert(1, outputVar)
+    result.add closingCall
 
-    step0 = steps[0]
-    stepOutput = genSym(nskVar, "pipe")
+    if defined(debugMacros) or defined(debugPipelines):
+      echo result.repr
 
-  pipelineBody.add quote do:
-    var `pipelineSteps` = newSeq[Future[void]]()
-    var `stepOutput` = asyncPipe()
-    add `pipelineSteps`, `step0`(`stream`, initWriter(`stepOutput`))
+  macro executePipeline*(start: AsyncInputStream, steps: varargs[untyped]): untyped =
+    var
+      stream = ident "stream"
+      pipelineSteps = ident "pipelineSteps"
+      pipelineBody = newTree(nnkStmtList)
 
-  var
-    stepInput = stepOutput
-
-  for i in 1 .. steps.len - 2:
-    var step = steps[i]
-    stepOutput = genSym(nskVar, "pipe")
+      step0 = steps[0]
+      stepOutput = genSym(nskVar, "pipe")
 
     pipelineBody.add quote do:
+      var `pipelineSteps` = newSeq[Future[void]]()
       var `stepOutput` = asyncPipe()
-      add `pipelineSteps`, `step`(initReader(`stepInput`), initWriter(`stepOutput`))
+      add `pipelineSteps`, `step0`(`stream`, initWriter(`stepOutput`))
 
-    stepInput = stepOutput
+    var
+      stepInput = stepOutput
 
-  var RetTypeExpr = copy steps[^1]
-  RetTypeExpr.insert(1, newCall("default", ident"AsyncInputStream"))
+    for i in 1 .. steps.len - 2:
+      var step = steps[i]
+      stepOutput = genSym(nskVar, "pipe")
 
-  var closingCall = steps[^1]
-  closingCall.insert(1, newCall(bindSym"initReader", stepInput))
+      pipelineBody.add quote do:
+        var `stepOutput` = asyncPipe()
+        add `pipelineSteps`, `step`(initReader(`stepInput`), initWriter(`stepOutput`))
 
-  pipelineBody.add quote do:
-    fsAwait allFutures(`pipelineSteps`)
-    `closingCall`
+      stepInput = stepOutput
 
-  result = quote do:
-    type UserOpRetType = type(`RetTypeExpr`)
+    var RetTypeExpr = copy steps[^1]
+    RetTypeExpr.insert(1, newCall("default", ident"AsyncInputStream"))
 
-    when UserOpRetType is Future:
-      type RetType = type(default(UserOpRetType).read)
-    else:
-      type RetType = UserOpRetType
+    var closingCall = steps[^1]
+    closingCall.insert(1, newCall(bindSym"initReader", stepInput))
 
-    proc pipelineProc(`stream`: AsyncInputStream): Future[RetType] {.async.} =
+    pipelineBody.add quote do:
+      fsAwait allFutures(`pipelineSteps`)
+      `closingCall`
+
+    result = quote do:
+      type UserOpRetType = type(`RetTypeExpr`)
+
       when UserOpRetType is Future:
-        var f = `pipelineBody`
-        return fsAwait(f)
+        type RetType = type(default(UserOpRetType).read)
       else:
-        return `pipelineBody`
+        type RetType = UserOpRetType
 
-    pipelineProc(`start`)
+      proc pipelineProc(`stream`: AsyncInputStream): Future[RetType] {.async.} =
+        when UserOpRetType is Future:
+          var f = `pipelineBody`
+          return fsAwait(f)
+        else:
+          return `pipelineBody`
 
-  when defined(debugMacros):
-    echo result.repr
+      pipelineProc(`start`)
+
+    when defined(debugMacros):
+      echo result.repr
 

--- a/tests/test_inputs.nim
+++ b/tests/test_inputs.nim
@@ -2,14 +2,10 @@
 
 import
   os, unittest2, strutils, random,
-  stew/ranges/ptr_arith, testutils,
+  testutils,
   ../faststreams, ../faststreams/textio
 
 setCurrentDir getAppDir()
-
-proc bytes(s: string): seq[byte] =
-  result = newSeqOfCap[byte](s.len)
-  for c in s: result.add byte(c)
 
 proc str(bytes: openarray[byte]): string =
   result = newStringOfCap(bytes.len)
@@ -28,7 +24,7 @@ const
   asciiTableFile = "files" / "ascii_table.txt"
   asciiTableContents = slurp(asciiTableFile)
 
-procSuite "input stream":
+suite "input stream":
   template emptyInputTests(suiteName, setupCode: untyped) =
     suite suiteName & " empty inputs":
       setup setupCode

--- a/tests/test_outputs.nim
+++ b/tests/test_outputs.nim
@@ -154,6 +154,15 @@ suite "output stream":
 
     checkOutputsMatch()
 
+  test "memcpy":
+    var x = 0x42'u8
+
+    nimSeq.add x
+    memStream.writeMemCopy x
+    let memStreamRes = memStream.getOutput
+
+    check memStreamRes == nimSeq
+
   template undelayedOutput(content: seq[byte]) {.dirty.} =
     nimSeq.add content
     streamWritingToExistingBuffer.write content

--- a/tests/test_pipelines.nim
+++ b/tests/test_pipelines.nim
@@ -1,128 +1,136 @@
 {.used.}
 
 import
-  # Std lib:
-  std/[strutils, random, base64, terminal],
-  # Other packages:
   testutils/unittests,
+
   # FastStreams modules:
-  ../faststreams/[pipelines, multisync],
-  # Testing modules:
-  ./base64 as fsBase64
+  ../faststreams/[pipelines, multisync]
 
-include system/timers
+when fsAsyncSupport:
+  import
+    # Std lib:
+    std/[strutils, random, base64, terminal],
+    # FastStreams modules:
+    ../faststreams/[pipelines, multisync],
+    # Testing modules:
+    ./base64 as fsBase64
 
-type
-  TestTimes = object
-    fsPipeline: Nanos
-    fsAsyncPipeline: Nanos
-    stdFunctionCalls: Nanos
+  include system/timers
 
-proc upcaseAllCharacters(i: InputStream, o: OutputStream) {.fsMultiSync.} =
-  let inputLen = i.len
-  if inputLen.isSome:
-    o.ensureRunway inputLen.get
+  type
+    TestTimes = object
+      fsPipeline: Nanos
+      fsAsyncPipeline: Nanos
+      stdFunctionCalls: Nanos
 
-  while i.readable:
-    o.write toUpperAscii(i.read.char)
+  proc upcaseAllCharacters(i: InputStream, o: OutputStream) {.fsMultiSync.} =
+    let inputLen = i.len
+    if inputLen.isSome:
+      o.ensureRunway inputLen.get
 
-  close o
+    while i.readable:
+      o.write toUpperAscii(i.read.char)
 
-proc printTimes(t: TestTimes) =
-  styledEcho "  cpu time [FS Sync  ]: ", styleBright, $t.fsPipeline, "ms"
-  styledEcho "  cpu time [FS Async ]: ", styleBright, $t.fsAsyncPipeline, "ms"
-  styledEcho "  cpu time [Std Lib  ]: ", styleBright, $t.stdFunctionCalls, "ms"
+    close o
 
-template timeit(timerVar: var Nanos, code: untyped) =
-  let t0 = getTicks()
-  code
-  timerVar = int(getTicks() - t0) div 1000000
+  proc printTimes(t: TestTimes) =
+    styledEcho "  cpu time [FS Sync  ]: ", styleBright, $t.fsPipeline, "ms"
+    styledEcho "  cpu time [FS Async ]: ", styleBright, $t.fsAsyncPipeline, "ms"
+    styledEcho "  cpu time [Std Lib  ]: ", styleBright, $t.stdFunctionCalls, "ms"
 
-proc getOutput(sp: AsyncInputStream, T: type string): Future[string] {.async.} =
-  # this proc is a quick hack to let the test pass
-  # do not use it in production code
-  let size = sp.totalUnconsumedBytes()
-  if size > 0:
-    var data = newSeq[byte](size)
-    discard sp.readinto(data)
-    result = cast[string](data)
+  template timeit(timerVar: var Nanos, code: untyped) =
+    let t0 = getTicks()
+    code
+    timerVar = int(getTicks() - t0) div 1000000
 
-procSuite "pipelines":
-  let loremIpsum = """
-    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
-    tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
-    veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex
-    ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate
-    velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
-    cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id
-    est laborum.
+  proc getOutput(sp: AsyncInputStream, T: type string): Future[string] {.async.} =
+    # this proc is a quick hack to let the test pass
+    # do not use it in production code
+    let size = sp.totalUnconsumedBytes()
+    if size > 0:
+      var data = newSeq[byte](size)
+      discard sp.readinto(data)
+      result = cast[string](data)
 
-  """
+  suite "pipelines":
+    const loremIpsum = """
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+      tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+      veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex
+      ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate
+      velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+      cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id
+      est laborum.
 
-  test "upper-case/base64 pipeline benchmark":
-    var
-      times: TestTimes
-      stdRes: string
-      fsRes: string
-      fsAsyncRes: string
+    """
 
-    let inputText = loremIpsum.repeat(5000)
+    test "upper-case/base64 pipeline benchmark":
+      var
+        times: TestTimes
+        stdRes: string
+        fsRes: string
+        fsAsyncRes: string
 
-    timeIt times.stdFunctionCalls:
-      stdRes = base64.decode(base64.encode(toUpperAscii(inputText)))
+      let inputText = loremIpsum.repeat(5000)
 
-    timeIt times.fsPipeline:
-      fsRes = executePipeline(unsafeMemoryInput(inputText),
+      timeIt times.stdFunctionCalls:
+        stdRes = base64.decode(base64.encode(toUpperAscii(inputText)))
+
+      timeIt times.fsPipeline:
+        fsRes = executePipeline(unsafeMemoryInput(inputText),
+                                upcaseAllCharacters,
+                                base64encode,
+                                base64decode,
+                                getOutput string)
+
+      timeIt times.fsAsyncPipeline:
+        fsAsyncRes = waitFor executePipeline(Async unsafeMemoryInput(inputText),
+                                            upcaseAllCharacters,
+                                            base64encode,
+                                            base64decode,
+                                            getOutput string)
+
+      check fsAsyncRes == stdRes
+      check fsRes == stdRes
+
+      printTimes times
+
+    asyncTest "upper-case/base64 async pipeline":
+      let pipe = asyncPipe()
+      let inputText = repeat(loremIpsum, 100)
+
+      proc pipeFeeder(s: AsyncOutputStream) {.gcsafe, async.} =
+        randomize 1234
+        var pos = 0
+
+        while pos != inputText.len:
+          let bytesToWrite = rand(15)
+
+          if bytesToWrite == 0:
+            s.write inputText[pos]
+            inc pos
+          else:
+            let endPos = min(pos + bytesToWrite, inputText.len)
+            s.writeAndWait inputText[pos ..< endPos]
+            pos = endPos
+
+          let sleep = rand(50) - 45
+          if sleep > 0:
+            await sleepAsync(sleep.milliseconds)
+
+        close s
+
+      asyncCheck pipeFeeder(pipe.initWriter)
+
+      let f = executePipeline(pipe.initReader,
                               upcaseAllCharacters,
                               base64encode,
                               base64decode,
                               getOutput string)
 
-    timeIt times.fsAsyncPipeline:
-      fsAsyncRes = waitFor executePipeline(Async unsafeMemoryInput(inputText),
-                                           upcaseAllCharacters,
-                                           base64encode,
-                                           base64decode,
-                                           getOutput string)
+      let fsAsyncres = await f
 
-    check fsAsyncRes == stdRes
-    check fsRes == stdRes
-
-    printTimes times
-
-  asyncTest "upper-case/base64 async pipeline":
-    let pipe = asyncPipe()
-    let inputText = repeat(loremIpsum, 100)
-
-    proc pipeFeeder(s: AsyncOutputStream) {.gcsafe, async.} =
-      randomize 1234
-      var pos = 0
-
-      while pos != inputText.len:
-        let bytesToWrite = rand(15)
-
-        if bytesToWrite == 0:
-          s.write inputText[pos]
-          inc pos
-        else:
-          let endPos = min(pos + bytesToWrite, inputText.len)
-          s.writeAndWait inputText[pos ..< endPos]
-          pos = endPos
-
-        let sleep = rand(50) - 45
-        if sleep > 0:
-          await sleepAsync(sleep.milliseconds)
-
-      close s
-
-    asyncCheck pipeFeeder(pipe.initWriter)
-
-    let f = executePipeline(pipe.initReader,
-                            upcaseAllCharacters,
-                            base64encode,
-                            base64decode,
-                            getOutput string)
-
-    let fsAsyncres = await f
-
-    check fsAsyncRes == toUpperAscii(inputText)
+      check fsAsyncRes == toUpperAscii(inputText)
+else:
+  test "pipelines":
+    skip


### PR DESCRIPTION
Chronos support is optional and should not have to be imported in order
to use faststreams for non-async use cases, as doing so pollutes the
global namespace and slows down compilation.

`async` support must now explicitly be enabled with
-d:async_backend=chronos|asyncdispatch

* avoid `ptr_arith` (port to toOpenArray from system.nim)
* avoid `procSuite`