### PR TITLE
Few minor improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -517,9 +517,9 @@ type PipelineResultProc*[T] = proc (i: InputStream): T
 
 Please note that `stream.getOutput` is an example of such a function.
 
-Pipelnes can be created with the `cretePipeline` API or executed in place with
-`executePipeline`. If the first input source is async, then the whole pipeline
-with be executing asynchronously which can result in a much lower memory usage.
+Pipelnes executed in place with `executePipeline` API. If the first input source is
+async, then the whole pipeline with be executing asynchronously which can result
+in a much lower memory usage.
 
 The pipeline transformation steps are usually employing the `fsMultiSync`
 pragma to make them usable in both synchronous and asynchronous scenarios.

--- a/faststreams/asynctools_adapters.nim
+++ b/faststreams/asynctools_adapters.nim
@@ -1,6 +1,9 @@
 import
   asynctools/asyncpipe,
-  inputs, outputs, buffers, multisync
+  inputs, outputs, buffers, multisync, async_backend
+
+when (not fsAsyncSupport):
+  {.fatal: "`-d:async_backend` has be to set".}
 
 export
   inputs, outputs, asyncpipe, fsMultiSync


### PR DESCRIPTION
- Remove the reference to non-existing `createPipeline` from the docs.

- Added check whether async_backend is set when `asynctools_adapters `is
imported. Without this change the compile error is very unclear (Future not
defined).