### PR TITLE
don't even notionally access element 0 of 0-length openArray

### DIFF
--- a/faststreams/buffers.nim
+++ b/faststreams/buffers.nim
@@ -11,7 +11,7 @@ type
     startAddr*, endAddr*: ptr byte
 
   Page* = object
-    consumedTo*: Natural
+    consumedTo*: int
     writtenTo*: Natural
     data*: ref string
 

--- a/faststreams/inputs.nim
+++ b/faststreams/inputs.nim
@@ -442,7 +442,11 @@ proc fileInput*(filename: string,
   return fileInput(file, offset, pageSize)
 
 proc unsafeMemoryInput*(mem: openArray[byte]): InputStreamHandle =
-  let head = unsafeAddr mem[0]
+  let head =
+    if mem.len > 0:
+      unsafeAddr mem[0]
+    else:
+      default(ptr byte)
 
   makeHandle InputStream(
     span: PageSpan(

--- a/faststreams/inputs.nim
+++ b/faststreams/inputs.nim
@@ -442,11 +442,7 @@ proc fileInput*(filename: string,
   return fileInput(file, offset, pageSize)
 
 proc unsafeMemoryInput*(mem: openArray[byte]): InputStreamHandle =
-  let head =
-    if mem.len > 0:
-      unsafeAddr mem[0]
-    else:
-      default(ptr byte)
+  let head = cast[ptr byte](mem)
 
   makeHandle InputStream(
     span: PageSpan(

--- a/tests/base64.nim
+++ b/tests/base64.nim
@@ -121,7 +121,7 @@ proc base64decode*(i: InputStream, o: OutputStream) {.fsMultiSync.} =
         inputChar(d)
         outputChar(c shl 6 or d shr 0)
   elif i.readable:
-    raise newException(ValueError, "The input stream has insufficient nymber of bytes for base64 decoding")
+    raise newException(ValueError, "The input stream has insufficient number of bytes for base64 decoding")
 
   close o
 

--- a/tests/test_pipelines.nim
+++ b/tests/test_pipelines.nim
@@ -41,7 +41,7 @@ when fsAsyncSupport:
   template timeit(timerVar: var Nanos, code: untyped) =
     let t0 = getTicks()
     code
-    timerVar = int(getTicks() - t0) div 1000000
+    timerVar = int64(getTicks() - t0) div 1000000
 
   proc getOutput(sp: AsyncInputStream, T: type string): Future[string] {.async.} =
     # this proc is a quick hack to let the test pass


### PR DESCRIPTION
Conceptually, this is attempting to get the base address of the `openArray`.

I checked that it so far seemed to always return the same results, where applicable, as the `unsafeAddr mem[0]` approach, and
```nim
proc baseAddr*[T](x: openArray[T]): pointer = cast[pointer](x)
```
from `nim-stew`, while using `pointer` rather than `ptr byte`, suggests that this should work as well.

It compiles to
```c
head = ((NU8*) (mem));
```
which is correct, as well.