### PR TITLE
Fix nim devel 32 bits

### DIFF
--- a/faststreams/textio.nim
+++ b/faststreams/textio.nim
@@ -20,7 +20,7 @@ when sizeof(int) == sizeof(int64):
     PromotedUintTypes = uint8|uint16|uint32
 else:
   type
-    CompiledIntTypes = int|int64
+    CompiledIntTypes = int
     PromotedIntTypes = int8|int16
     CompiledUIntTypes = uint|uint64
     PromotedUintTypes = uint8|uint16

--- a/faststreams/textio.nim
+++ b/faststreams/textio.nim
@@ -20,9 +20,9 @@ when sizeof(int) == sizeof(int64):
     PromotedUintTypes = uint8|uint16|uint32
 else:
   type
-    CompiledIntTypes = int
+    CompiledIntTypes = int32|int64
     PromotedIntTypes = int8|int16
-    CompiledUIntTypes = uint|uint64
+    CompiledUIntTypes = uint32|uint64
     PromotedUintTypes = uint8|uint16
 
 # The following code implements writing numbers to a stream without going


### PR DESCRIPTION
Nim devel changed int matching rules
Causes:
```
/home/runner/.nimble/pkgs/faststreams-0.3.0/faststreams/textio.nim(91, 14) Error: type mismatch
Expression: writeText(s, MatchingUInt(0) - MatchingUInt(x))
  [1] s: OutputStream
  [2] MatchingUInt(0) - MatchingUInt(x): uint32

Expected one of (first mismatch at position [#]):
[2] proc writeText(s: OutputStream; x: CompiledIntTypes)
[2] proc writeText(s: OutputStream; x: CompiledUIntTypes)
```