### PR TITLE
Remove Nim 1.2 and 1.4 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
             cpu: amd64
           #- os: windows
             #cpu: i386
-        branch: [version-1-2, version-1-4, version-1-6, devel]
+        branch: [version-1-6, devel]
         include:
           - target:
               os: linux

--- a/faststreams.nimble
+++ b/faststreams.nimble
@@ -7,7 +7,7 @@ description   = "Nearly zero-overhead input/output streams for Nim"
 license       = "Apache License 2.0"
 skipDirs      = @["tests"]
 
-requires "nim >= 1.2.0",
+requires "nim >= 1.6.0",
          "stew",
          "unittest2"
 
@@ -16,9 +16,8 @@ let lang = getEnv("NIMLANG", "c") # Which backend (c/cpp/js)
 let flags = getEnv("NIMFLAGS", "") # Extra flags for the compiler
 let verbose = getEnv("V", "") notin ["", "0"]
 
-let styleCheckStyle = if (NimMajor, NimMinor) < (1, 6): "hint" else: "error"
 let cfg =
-  " --styleCheck:usages --styleCheck:" & styleCheckStyle &
+  " --styleCheck:usages --styleCheck:error" &
   (if verbose: "" else: " --verbosity:0 --hints:off") &
   " --skipParentCfg --skipUserCfg --outdir:build --nimcache:build/nimcache -f"
 


### PR DESCRIPTION
Same CI success/failure patterns as `master`, no regressions. 1.6 worked before, and works now. `devel` failed before, and still does, for the same reasons.