### PR TITLE
avoid UB writing nothing to outputs

### DIFF
--- a/faststreams/outputs.nim
+++ b/faststreams/outputs.nim
@@ -737,6 +737,8 @@ when fsAsyncSupport:
     writeAndWait(sp, memCopyToBytes(value))
 
 proc writeBytesToCursor(c: var WriteCursor, bytes: openArray[byte]) =
+  # https://github.com/nim-lang/Nim/issues/22149
+  #
   # Nim represents a zero-length openArray as a (NULL, 0) base+length tuple.
   #
   # https://gcc.gnu.org/gcc-4.9/porting_to.html

--- a/faststreams/outputs.nim
+++ b/faststreams/outputs.nim
@@ -801,18 +801,9 @@ proc finalWrite*(cursor: var WriteCursor, data: openArray[byte]) =
   finalize cursor
 
 proc finalWrite*(c: var VarSizeWriteCursor, data: openArray[byte]) =
-  # Nim represents a zero-length openArray as a (NULL, 0) base+length tuple.
-  #
-  # https://gcc.gnu.org/gcc-4.9/porting_to.html
-  # "The pointers passed to memmove (and similar functions in <string.h>) must
-  # be non-null even when nbytes==0, so GCC can use that information to remove
-  # the check after the memmove call."
-  #
-  # https://en.cppreference.com/w/cpp/string/byte/memcpy
-  # "If either dest or src is an invalid or null pointer, the behavior is
-  # undefined, even if count is zero."
-  if data.len == 0:
-    return
+  # TODO ensure adding early-return for zero-length input is safe, or if not,
+  # what is. It can't make it all the way to copyMem, though, regardless, and
+  # remain non-UB.
 
   template cursor: auto = WriteCursor(c)
 


### PR DESCRIPTION
Example gcc 12.3.0 UBSAN output:
```
Nim/lib/system/memory.nim:10:24: runtime error: null pointer passed as argument 2, which is declared to never be null
```

Example clang 14.0.6 output:
```
Nim/lib/system/memory.nim:10:40: runtime error: null pointer passed as argument 2, which is declared to never be null
/usr/include/string.h:44:28: note: nonnull attribute specified here
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior Nim/lib/system/memory.nim:10:40
```