### PR TITLE
fix multiple reads in same scope

### DIFF
--- a/tests/test_inputs.nim
+++ b/tests/test_inputs.nim
@@ -114,6 +114,25 @@ suite "input stream":
             fileContents.add input.read.char
           break
 
+      elif r < 60:
+        # Test the ability to call readable() and read() multiple times from
+        # the same scope.
+        let readSize = 6 + rand(10)
+
+        if input.readable(readSize):
+          fileContents.add input.read(readSize).str
+        else:
+          while input.readable:
+            fileContents.add input.read.char
+          break
+
+        if input.readable(readSize):
+          fileContents.add input.read(readSize).str
+        else:
+          while input.readable:
+            fileContents.add input.read.char
+          break
+
       else:
         if input.readable:
           fileContents.add input.read.char


### PR DESCRIPTION
This effectively inlines the `useHeapMem` and `useStackMem` pseudo-closure-templates into `readNImpl`.