### PR TITLE
Allow closing default-inited InputStream/OutputStream (fixes #52)

### DIFF
--- a/faststreams/inputs.nim
+++ b/faststreams/inputs.nim
@@ -121,8 +121,7 @@ when fsAsyncSupport:
     preventFurtherReading InputStream(s)
 
 template makeHandle*(sp: InputStream): InputStreamHandle =
-  let s = sp
-  InputStreamHandle(s: s)
+  InputStreamHandle(s: sp)
 
 proc close*(s: InputStream,
             behavior = dontWaitAsyncClose)
@@ -133,6 +132,9 @@ proc close*(s: InputStream,
   ## If the underlying input device requires asynchronous closing
   ## and `behavior` is set to `waitAsyncClose`, this proc will use
   ## `waitFor` to block until the async operation completes.
+  if s == nil:
+    return
+
   s.disconnectInputDevice()
   s.preventFurtherReading()
   when fsAsyncSupport:
@@ -147,11 +149,12 @@ when fsAsyncSupport:
   template close*(sp: AsyncInputStream) =
     ## Starts the asychronous closing of the stream and returns a future that
     ## tracks the closing operation.
-    let s = InputStream sp
-    disconnectInputDevice(s)
-    preventFurtherReading(s)
-    if s.closeFut != nil:
-      fsAwait s.closeFut
+    if sp != nil:
+      let s = InputStream sp
+      disconnectInputDevice(s)
+      preventFurtherReading(s)
+      if s.closeFut != nil:
+        fsAwait s.closeFut
 
 template closeNoWait*(sp: MaybeAsyncInputStream) =
   ## Close the stream without waiting even if's async.

--- a/faststreams/outputs.nim
+++ b/faststreams/outputs.nim
@@ -147,6 +147,9 @@ proc flush*(s: OutputStream) =
 proc close*(s: OutputStream,
             behavior = dontWaitAsyncClose)
            {.raises: [IOError, Defect].} =
+  if s == nil:
+    return
+
   flush s
   disconnectOutputDevice(s)
   when fsAsyncSupport:
@@ -962,12 +965,13 @@ when fsAsyncSupport:
     proc flushAsync*(s: AsyncOutputStream) {.async.} =
       flush s
 
-    template close*(sp: AsyncOutputStream) =
-      let s = OutputStream sp
-      flush(Async s)
-      disconnectOutputDevice(s)
-      if s.closeFut != nil:
-        fsAwait s.closeFut
+    proc close*(sp: AsyncOutputStream) =
+      if sp != nil:
+        let s = OutputStream sp
+        flush(Async s)
+        disconnectOutputDevice(s)
+        if s.closeFut != nil:
+          fsAwait s.closeFut
 
     proc closeAsync*(s: AsyncOutputStream) {.async.} =
       close s

--- a/tests/test_inputs.nim
+++ b/tests/test_inputs.nim
@@ -43,6 +43,9 @@ suite "input stream":
       test "next returns none":
         check input.next.isNone
 
+      test "input can be closed":
+        input.close()
+
   emptyInputTests "memoryInput":
     var input = InputStream()
 
@@ -154,6 +157,10 @@ suite "input stream":
       expect CatchableError: discard memFileInput(fileName)
 
       check not fileExists(fileName)
+
+    test "can close nil InputStream":
+      var v: InputStream
+      v.close()
 
     test "non-blocking reads":
       let s = fileInput(asciiTableFile, pageSize = 100)

--- a/tests/test_outputs.nim
+++ b/tests/test_outputs.nim
@@ -492,3 +492,7 @@ suite "randomized tests":
 
     check:
       res[0..<data.len] == data
+
+  test "can close default OutputStream":
+    var v: OutputStream
+    v.close()


### PR DESCRIPTION
Often used in constructs like the following:
```nim
var v: InputStream
try:
  ...
finally:
  close(v)
```

In the above, if an exception is raised while constructing the stream, it gets messy.

Given `close` can already be called multiple times on the same stream, allowing it for nils seems preferable.