### PR TITLE
PageBuffers revamp

### DIFF
--- a/faststreams/buffers.nim
+++ b/faststreams/buffers.nim
@@ -8,20 +8,74 @@ export
 
 type
   PageSpan* = object
+    ## View into memory area backed by a Page, allowing efficient access.
+    ##
+    ## Unlike openArray, lifetime must be managed manually
+    ## Similar to UncheckedArray, range checking is generally not performed.
+    ##
+    ## The end address points to the memory immediately after the last entry,
+    ## meaning that when startAddr == endAddr, the span is empty.
+    ## endAddr is used instead of length so that when advancing, only a single
+    ## pointer needs to be updated.
     startAddr*, endAddr*: ptr byte
 
   Page* = object
+    ## A Page is a contiguous fixed-size memory area for managing a stream of
+    ## bytes.
+    ##
+    ## Each page is divided into input and output sequences - the output
+    ## sequence is the part prepared for writing while the input is the
+    ## part already written and waiting to be read.
+    ##
+    ## As data is written, the output sequence is moved to the input sequence
+    ## by adjusting the `writtenTo` counter. Similarly, as data is read from the
+    ## input sequence, `consumedTo` is updated to reflect the number of bytes read.
+    ##
+    ## A page may also be created to reserve a part of the output sequence for
+    ## delayed writing, such as when a length prefix is written after producing
+    ## the data. Such a page will have `reservedTo` set, and as long as such a
+    ## marker exists, the following pages will not be made available for
+    ## consuming.
+    ##
+    ## Data is typically read and written in batches represented by a PageSpan,
+    ## where each batch can be bulk-processed efficiently.
     consumedTo*: int
+      ## Number of bytes consumed from the input sequence
     writtenTo*: Natural
+      ## Number of bytes written to the input sequence
+    reservedTo*: Natural
+      ## Number of bytes reserved for future writing
     data*: ref seq[byte]
+      ## Memory backing the page - allocated once and never resized to maintain
+      ## pointer stability. Multiple pages may share the same buffer, which
+      ## specially happens when reserving parts of a page for delayed writing.
 
   PageRef* = ref Page
 
   PageBuffers* = ref object
+    ## PageBuffers is a memory management structure designed for efficient
+    ## buffering of streaming data. It divides the buffer into pages (blocks of
+    ## memory), which are managed in a queue.
+    ##
+    ## This approach is suitable in scenarios where data arrives or is consumed
+    ## in chunks of varying size, such as when decoding a network stream or file
+    ## into structured data.
+    ##
+    ## Pages are kept in a deque. New pages are prepared as needed when writing,
+    ## and fully consumed pages are removed after reading.
+    ##
+    ## Pages can also be reserved to delay the writing of a prefix while data
+    ## is being buffered. In such cases, writing can continue but reading will
+    ## be blocked until the reservation is committed.
     pageSize*: Natural
+      ## Default size of freshly allocated pages - pages are typically of at
+      ## least this size but may also be larger
+
     maxBufferedBytes*: Natural
+      ## TODO: currently unusued
 
     queue*: Deque[PageRef]
+
     when fsAsyncSupport:
       waitingReader*: Future[void]
       waitingWriter*: Future[void]
@@ -36,6 +90,10 @@ const
     # that go through a fast O(0) path in the allocator.
   defaultPageSize* = 4096 - nimAllocatorMetadataSize
   maxStackUsage* = 16384
+
+when not declared(newSeqUninit): # nim 2.2+
+  template newSeqUninit[T: byte](len: int): seq[byte] =
+    newSeqUninitialized[byte](len)
 
 when debugHelpers:
   proc describeBuffers*(context: static string, buffers: PageBuffers) =
@@ -60,125 +118,10 @@ func openArrayToPair*(a: var openArray[byte]): (ptr byte, Natural) =
   else:
     (nil, Natural(0))
 
-template allocationStart*(page: PageRef): ptr byte =
-  baseAddr page.data[]
-
-func readableStart*(page: PageRef): ptr byte =
-  offset(page.allocationStart(), page.consumedTo)
-
-func readableEnd*(page: PageRef): ptr byte =
-  offset(page.allocationStart(), page.writtenTo)
-
-template writableStart*(page: PageRef): ptr byte =
-  readableEnd(page)
-
-func allocationEnd*(page: PageRef): ptr byte =
-  offset(page.allocationStart(), page.data[].len)
-
-func pageLen*(page: PageRef): Natural =
-  page.writtenTo - page.consumedTo
-
-template pageBytes*(page: PageRef): var openArray[byte] =
-  var baseAddr = cast[ptr UncheckedArray[byte]](allocationStart(page))
-  toOpenArray(baseAddr, page.consumedTo, page.writtenTo - 1)
-
-template pageChars*(page: PageRef): openArray[char] =
-  var baseAddr = cast[ptr UncheckedArray[char]](allocationStart(page))
-  toOpenArray(baseAddr, page.consumedTo, page.writtenTo - 1)
-
-func obtainReadableSpan*(buffers: PageBuffers, maxLen: Option[Natural]): PageSpan =
-  if buffers.queue.len == 0:
-    return default(PageSpan)
-
-  var page = buffers.queue[0]
-  var unconsumedLen = page.writtenTo - page.consumedTo
-  if unconsumedLen == 0:
-    if buffers.queue.len > 1:
-      discard buffers.queue.popFirst
-      page = buffers.queue[0]
-      unconsumedLen = page.writtenTo - page.consumedTo
-    else:
-      return default(PageSpan)
-
-  let
-    baseAddr = page.allocationStart
-    startAddr = offset(baseAddr, page.consumedTo)
-
-  let usableLen = if maxLen.isSome():
-    min(unconsumedLen, maxLen.get())
-  else:
-    unconsumedLen
-
-  page.consumedTo += usableLen
-
-  PageSpan(startAddr: startAddr,
-           endAddr: offset(startAddr, usableLen))
-
-func returnReadableSpan*(buffers: PageBuffers, bytes: Natural) =
-  # return part of span that was previously given by `obtainReadableSpan`
-  assert buffers.queue.len > 0
-  buffers.queue.peekFirst.consumedTo -= bytes
-
-func writableSpan*(page: PageRef): PageSpan =
-  let baseAddr = allocationStart(page)
-  PageSpan(startAddr: offset(baseAddr, page.writtenTo),
-           endAddr: offset(baseAddr, page.data[].len))
-
-func fullSpan*(page: PageRef): PageSpan =
-  let baseAddr = page.allocationStart
-  PageSpan(startAddr: baseAddr, endAddr: offset(baseAddr, page.data[].len))
-
-func initPageBuffers*(pageSize: Natural,
-                      maxBufferedBytes: Natural = 0): PageBuffers =
-  # TODO: remove the unbuferred streams
-  if pageSize > 0:
-    return PageBuffers(pageSize: pageSize,
-                       maxBufferedBytes: maxBufferedBytes)
-
 template allocRef[T: not ref](x: T): ref T =
   let res = new type(x)
   res[] = x
   res
-
-func trackWrittenToEnd*(buffers: PageBuffers) =
-  if buffers.queue.len > 0:
-    let page = buffers.queue.peekLast
-    page.writtenTo = page.data[].len
-
-func trackWrittenTo*(buffers: PageBuffers, spanHeadPos: ptr byte) =
-  if buffers != nil and buffers.queue.len > 0:
-    var topPage = buffers.queue.peekLast
-    topPage.writtenTo = distance(topPage.allocationStart, spanHeadPos)
-
-template allocWritablePage*(pageSize: Natural, writtenToParam: Natural = 0): auto =
-  PageRef(data: allocRef newSeqUninitialized[byte](pageSize),
-          writtenTo: writtenToParam)
-
-func addWritablePage*(buffers: PageBuffers, pageSize: Natural): PageRef =
-  trackWrittenToEnd(buffers)
-  result = allocWritablePage(pageSize)
-  buffers.queue.addLast result
-
-func getWritablePage*(buffers: PageBuffers,
-                      preferredSize: Natural): PageRef =
-  if buffers.queue.len > 0:
-    let lastPage = buffers.queue.peekLast
-    if lastPage.writtenTo < lastPage.data[].len:
-      return lastPage
-
-  return addWritablePage(buffers, preferredSize)
-
-func addWritablePage*(buffers: PageBuffers): PageRef =
-  buffers.addWritablePage(buffers.pageSize)
-
-template getWritableSpan*(buffers: PageBuffers): PageSpan =
-  let page = getWritablePage(buffers, buffers.pageSize)
-  writableSpan(page)
-
-func fromBytes(src: pointer, srcLen: Natural): seq[byte] =
-  result = newSeqUninitialized[byte](srcLen)
-  if srcLen > 0:
-    copyMem(baseAddr result, src, srcLen)
 
 func nextAlignedSize*(minSize, pageSize: Natural): Natural =
   if pageSize == 0:
@@ -186,46 +129,437 @@ func nextAlignedSize*(minSize, pageSize: Natural): Natural =
   else:
     max(((minSize + pageSize - 1) div pageSize) * pageSize, pageSize)
 
-func appendUnbufferedWrite*(buffers: PageBuffers,
-                            src: pointer, srcLen: Natural) =
-  if srcLen == 0:
+# BEWARE! These templates violate the double evaluation
+#         safety measures in order to produce better inlined
+#         code. We are using a `var` type to make it harder
+#         to accidentally misuse them.
+template len*(span: var PageSpan): Natural =
+  distance(span.startAddr, span.endAddr)
+
+func `$`*(span: PageSpan): string =
+  # avoid repr(ptr byte) since it can crash if the pointee is gone
+  var span = span
+  "[startAddr: " & repr(pointer(span.startAddr)) & ", len: " & $span.len & "]"
+
+template atEnd*(span: var PageSpan): bool =
+  span.startAddr == span.endAddr
+
+template hasRunway*(span: var PageSpan): bool =
+  not span.atEnd()
+
+template advance*(span: var PageSpan, numberOfBytes: Natural = 1) =
+  span.startAddr = offset(span.startAddr, numberOfBytes)
+
+template split*(span: var PageSpan, pos: Natural): PageSpan =
+  let other = PageSpan(startAddr: span.startAddr, endAddr: offset(span.startAddr, pos))
+  span.advance(pos)
+  other
+
+template read*(span: var PageSpan): byte =
+  let b = span.startAddr[]
+  span.advance(1)
+  b
+
+func read*(span: var PageSpan, val: var openArray[byte]) {.inline.} =
+  if val.len > 0: # avoid accessing addr val[0] when it's empty
+    copyMem(addr val[0], span.startAddr, val.len)
+    span.advance(val.len)
+
+func write*(span: var PageSpan, val: openArray[byte]) {.inline.} =
+  if val.len > 0: # avoid accessing addr val[0] when it's empty
+    copyMem(span.startAddr, unsafeAddr val[0], val.len)
+    span.advance(val.len)
+
+template write*(span: var PageSpan, val: byte) =
+  span.startAddr[] = val
+  span.startAddr = offset(span.startAddr, 1)
+
+template data*(span: var PageSpan): var openArray[byte] =
+  makeOpenArray(span.startAddr, span.len())
+
+template allocationStart*(page: PageRef): ptr byte =
+  baseAddr page.data[]
+
+func readableStart*(page: PageRef): ptr byte {.inline.} =
+  offset(page.allocationStart(), page.consumedTo)
+
+func readableEnd*(page: PageRef): ptr byte {.inline.} =
+  offset(page.allocationStart(), page.writtenTo)
+
+func reservedEnd*(page: PageRef): ptr byte {.inline.} =
+  offset(page.allocationStart(), page.reservedTo)
+
+template writableStart*(page: PageRef): ptr byte =
+  readableEnd(page)
+
+func allocationEnd*(page: PageRef): ptr byte {.inline.} =
+  offset(page.allocationStart(), page.data[].len)
+
+func reserved*(page: PageRef): bool {.inline.} =
+  page.reservedTo > 0
+
+func len*(page: PageRef): Natural {.inline} =
+  ## The number of bytes that can be read from this page, ie what would be
+  ## returned by `consume`.
+  page.writtenTo - page.consumedTo
+
+func capacity*(page: PageRef): Natural {.inline.} =
+  ## The amount of bytes that can be written to this page, ie what would be
+  ## returned by `prepare`.
+  page.data[].len - page.writtenTo
+
+template data*(pageParam: PageRef): openArray[byte] =
+  ## Currnet input sequence, or what would be returned by `consume`
+  let page = pageParam
+  var baseAddr = cast[ptr UncheckedArray[byte]](allocationStart(page))
+  toOpenArray(baseAddr, page.consumedTo, page.writtenTo - 1)
+
+func prepare*(page: PageRef): PageSpan =
+  ## Return a span representing the output sequence of this page, ie the
+  ## of space available for writing, limited to `len` bytes.
+  ##
+  ## After writing data to the span, `commit` should be called with the number
+  ## of bytes written (or the advanced span).
+  ##
+  ## `len` must not be greater than `page.capacity()`.
+  let baseAddr = allocationStart(page)
+  PageSpan(startAddr: offset(baseAddr, page.writtenTo),
+           endAddr: offset(baseAddr, page.data[].len))
+
+func prepare*(page: PageRef, len: Natural): PageSpan =
+  ## Return a span representing the output sequence of this page, ie the
+  ## of space available for writing, limited to `len` bytes.
+  ##
+  ## After writing data to the span, `commit` should be called with the number
+  ## of bytes written (or the advanced span).
+  ##
+  ## `len` must not be greater than `page.capacity()`.
+  fsAssert len <= page.capacity()
+  let
+    baseAddr = allocationStart(page)
+    startAddr = offset(baseAddr, page.writtenTo)
+    endAddr = offset(startAddr, len)
+  PageSpan(startAddr: startAddr, endAddr: endAddr)
+
+func contains*(page: PageRef, address: ptr byte): bool {.inline.} =
+  let span = page.prepare()
+  address >= span.startAddr and address <= span.endAddr
+
+func commit*(page: PageRef) =
+  ## Mark the span returned by `prepare` as committed, allowing it to be
+  ## accessed by `consume`
+  page.reservedTo = 0
+  page.writtenTo = page.data[].len()
+
+func commit*(page: PageRef, len: Natural) =
+  ## Mark `len` prepared bytes as committed, allowing them to be accessed by
+  ## `consume`. `len` may be fewer bytes than were returned by `prepare`.
+  fsAssert len <= page.capacity()
+  page.reservedTo = 0
+  page.writtenTo += len
+
+func consume*(page: PageRef, maxLen = Natural.high()): PageSpan =
+  ## Consume up to `maxLen` bytes committed to this page returning the
+  ## corresponding span. May return a span shorter than `maxLen`.
+  ##
+  ## The span remains valid until the next consume call.
+  let
+    startAddr = page.readableStart()
+    bytes = min(page.len, maxLen)
+    endAddr = offset(startAddr, bytes)
+
+  page.consumedTo += bytes
+
+  PageSpan(startAddr: startAddr, endAddr: endAddr)
+
+func consume*(page: PageRef): PageSpan =
+  ## Consume all bytes committed to this page returning the corresponding span.
+  ##
+  ## The span remains valid until the next consume call.
+
+  page.consume(page.len)
+
+func unconsume(page: PageRef, len: int) =
+  ## Return bytes from the last `consume` call to the Page, making them available
+  ## for reading again.
+  fsAssert len < page.consumedTo, "cannot unconsume more bytes than were consumed"
+  page.consumedTo -= len
+
+func init*(_: type PageRef, data: ref seq[byte], pos: int): PageRef =
+  fsAssert data != nil and data[].len > 0
+  fsAssert pos <= data[].len
+  PageRef(data: data, consumedTo: pos, writtenTo: pos)
+
+func init*(_: type PageRef, pageSize: Natural): PageRef =
+  fsAssert pageSize > 0
+  PageRef(data: allocRef newSeqUninit[byte](pageSize))
+
+func nextAlignedSize*(buffers: PageBuffers, len: Natural): Natural =
+  nextAlignedSize(len, buffers.pageSize)
+
+func capacity*(buffers: PageBuffers): int =
+  if buffers.queue.len > 0:
+    buffers.queue.peekLast.capacity()
+  else:
+    0
+
+func prepare*(buffers: PageBuffers): PageSpan =
+  ## Return the largest contiguous writable memory area currently available or
+  ## allocate a new page if there is no space.
+  ##
+  ## `capacity` can be used to check how much space is available allocation-free
+  ## before calling `prepare`.
+  ##
+  ## Calling `prepare` multiple times without a `commit` in between will result
+  ## in the same span being returned.
+  if buffers.queue.len() == 0 or buffers.queue.peekLast().capacity() == 0:
+    buffers.queue.addLast PageRef.init(buffers.pageSize)
+
+  buffers.queue.peekLast().prepare()
+
+func prepare*(buffers: PageBuffers, minLen: Natural): PageSpan =
+  ## Return a contiguous span of at least `minLen` bytes, switching to a
+  ## new page if need be.
+  ##
+  ## The span returned by `prepare` remains valid until the next call to either
+  ## `reserve` or `commit`.
+  ##
+  ## Calling prepare may result in space being wasted when the desired allocation
+  ## does not not fit in the current page. Use `prepare()` to avoid this situation
+  ## or call `prepare` with your best guess of the total maximum memory that will
+  ## be needed.
+  ##
+  ## Calling `prepare` multiple times without a `commit` in between will result
+  ## in the same span being returned.
+  if buffers.queue.len() == 0 or buffers.queue.peekLast().capacity() < minLen:
+      # Create a new buffer for the desired runway, ending the current buffer
+      # potentially without using its entire space because existing write
+      # cursors may point to the memory inside it.
+      # In git history, one can find code that moves data from the existing page
+      # data to the new buffer - this would be a good idea if it wasn't for the
+      # fact that it would invalidate pointers to the previous buffer.
+
+    buffers.queue.addLast PageRef.init(buffers.nextAlignedSize(minLen))
+
+  buffers.queue.peekLast().prepare()
+
+func reserve*(buffers: PageBuffers, len: Natural): PageSpan =
+  ## Reserve a span in a page that is frozen for reading until the span is
+  ## committed. The reserved span must be committed even if it's not written to,
+  ## to release subsequent writes for reading.
+  ##
+  ## `reserve` is used to create a writeable area whose size and contents are
+  ## unknown at the time of reserve but whose maximum size is bounded and
+  ## reasonable.
+  ##
+  ## Calling `reserve` multiple times will result in a new span being returned
+  ## every time - each reserved span must be committed separately.
+  ##
+  ## If len is 0, no reservation is made.
+  if len == 0:
+    # If the reservation is empty, we'd end up with overlapping pages in the
+    # buffer which would make finding the span (to commit it) tricky
+    return PageSpan()
+
+  if buffers.queue.len() == 0 or buffers.queue.peekLast().capacity() < len:
+    buffers.queue.addLast PageRef.init(nextAlignedSize(len, buffers.pageSize))
+
+  let page = buffers.queue.peekLast()
+  page.reservedTo = page.writtenTo + len
+
+  # The next `prepare` / `reserve` will go into a fresh part
+  buffers.queue.addLast PageRef.init(page.data, page.reservedTo)
+
+  let
+    startAddr = page.writableStart
+    endAddr = offset(startAddr, len) # Same as reservedTo
+
+  PageSpan(startAddr: startAddr, endAddr: endAddr)
+
+func commit*(buffers: PageBuffers, len: Natural) =
+  ## Commit `len` bytes from a span previously given by the last call to `prepare`.
+  fsAssert buffers.queue.len > 0, "Must call prepare with at least `len` bytes"
+  buffers.queue.peekLast().commit(len)
+
+func commit*(buffers: PageBuffers, span: PageSpan) =
+  ## Commit a span previously return by `prepare` or `reserve`, committing all
+  ## bytes that were written to the span.
+  ##
+  ## Spans received from `reserve` may be committed in any order - the data will
+  ## be made available to `consume` in `reserve` order as soon as all preceding
+  ## reservations have been committed.
+  fsAssert span.endAddr >= span.startAddr, "Buffer overrun when writing span"
+
+  if span.startAddr == nil: # zero-length reservations
     return
 
-  if buffers.queue.len == 0:
-    buffers.queue.addLast PageRef(
-      data: allocRef fromBytes(src, srcLen),
-      writtenTo: srcLen)
+  var span = span
+
+  for ridx in 1..buffers.queue.len():
+    let page = buffers.queue[^ridx]
+
+    if span.startAddr in page:
+      if ridx < buffers.queue.len():
+        # A non-reserved page may share end address with the resered address of
+        # the preceding page if the reservation exactly covers the end of a page
+        # and no allocation has been done yet
+        let page2 = buffers.queue[^(ridx + 1)]
+        if page2.reservedTo > 0 and span.endAddr == page2.reservedEnd():
+          page2.commit(distance(page2.writableStart(), span.startAddr))
+          return
+
+      page.commit(distance(page.writableStart(), span.startAddr))
+      return
+
+  fsAssert false, "Could not find page to commit"
+
+func consumable*(buffers: PageBuffers): int =
+  ## Total number of bytes ready to be consumed - it may take several calls to
+  ## `consume` to get all of them!
+  var len = 0
+  for b in buffers.queue:
+    if b.reservedTo > 0:
+      break
+
+    len += b.len
+  len
+
+func consume*(buffers: PageBuffers, maxLen = int.high()): PageSpan =
+  ## Return a span representing up to `maxLen` bytes from a single page. The
+  ## return span is valid until the next call to `consume`.
+  ##
+  ## Calling code should make no assumptions about the number of `consume` calls
+  ## needed to consume a corresponding amount of commits - ie commits may be
+  ## split and consolidated as optimizations and features are implemented.
+  var page: PageRef
+  while buffers.queue.len > 0:
+    let tmp = buffers.queue.peekFirst()
+    if tmp.reservedTo > 0: # Page has been reserved and is waiting for a commit
+      break
+
+    if tmp.len() > 0:
+      page = tmp
+      break
+
+    discard buffers.queue.popFirst()
+
+  if page == nil:
+    PageSpan() # No ready pages
   else:
-    var
-      src = src
-      srcLen = srcLen
-      lastPage = buffers.queue.peekLast
-      lastPageLen = lastPage.data[].len
-      unusedBytes = lastPageLen - lastPage.writtenTo
+    page.consume(maxLen)
 
-    if unusedBytes > 0:
-      let unusedBytesStart = lastPage.writableStart()
-      if unusedBytes >= srcLen:
-        copyMem(unusedBytesStart, src, srcLen)
-        lastPage.writtenTo += srcLen
-        return
-      else:
-        copyMem(unusedBytesStart, src, unusedBytes)
-        lastPage.writtenTo = lastPageLen
-        src = offset(src, unusedBytes)
-        srcLen -= unusedBytes
+func unconsume*(buffers: PageBuffers, bytes: Natural) =
+  ## Return bytes that were given by the previous call to `consume`
+  fsAssert buffers.queue.len > 0
+  buffers.queue.peekFirst.consumedTo -= bytes
 
-    let nextPageSize = nextAlignedSize(srcLen, buffers.pageSize)
-    let nextPage = buffers.addWritablePage(nextPageSize)
+func write*(buffers: PageBuffers, val: openArray[byte]) =
+  if val.len > 0:
+    var written = 0
+    if buffers.capacity() > 0: # Use up whatever space is left in the current page
+      var span = buffers.prepare()
+      written = min(span.len, val.len)
 
-    copyMem(nextPage.writableStart(), src, srcLen)
-    nextPage.writtenTo = srcLen
+      span.write(val.toOpenArray(0, written - 1))
+      buffers.commit(written)
+
+    if written < val.len: # Put the rest in a fresh page
+      let remaining = val.len - written
+      var span = buffers.prepare(remaining)
+      span.write(val.toOpenArray(written, val.len - 1))
+      buffers.commit(remaining)
+
+func write*(buffers: PageBuffers, val: byte) =
+  buffers.write([val])
+
+func init*(_: type PageBuffers, pageSize: Natural, maxBufferedBytes: Natural = 0): PageBuffers =
+  fsAssert pageSize > 0
+  PageBuffers(pageSize: pageSize, maxBufferedBytes: maxBufferedBytes)
+
+template pageBytes*(page: PageRef): var openArray[byte] {.deprecated: "data".} =
+  page.data()
+
+template pageChars*(page: PageRef): var openArray[char] {.deprecated: "data".} =
+  var baseAddr = cast[ptr UncheckedArray[char]](allocationStart(page))
+  toOpenArray(baseAddr, page.consumedTo, page.writtenTo - 1)
+
+func pageLen*(page: PageRef): Natural {.deprecated: "len".} =
+  page.writtenTo - page.consumedTo
+
+func writableSpan*(page: PageRef): PageSpan {.deprecated: "prepare".} =
+  page.prepare()
+
+func fullSpan*(page: PageRef): PageSpan {.deprecated: "data or prepare".} =
+  let baseAddr = page.allocationStart
+  PageSpan(startAddr: baseAddr, endAddr: offset(baseAddr, page.data[].len))
+
+template bumpPointer*(span: var PageSpan, numberOfBytes: Natural = 1) {.deprecated: "advance".}=
+  span.advance(numberOfBytes)
+template writeByte*(span: var PageSpan, val: byte) {.deprecated: "write".} =
+  span.write(val)
+
+func obtainReadableSpan*(buffers: PageBuffers, maxLen: Option[Natural]): PageSpan {.deprecated: "consume".} =
+  buffers.consume(maxLen.get(int.high()))
+
+func returnReadableSpan*(buffers: PageBuffers, bytes: Natural) {.deprecated: "unconsume".} =
+  fsAssert buffers.queue.len > 0
+  buffers.queue.peekFirst.consumedTo -= bytes
+
+func initPageBuffers*(pageSize: Natural,
+                      maxBufferedBytes: Natural = 0): PageBuffers {.deprecated: "init".} =
+  if pageSize == 0:
+    nil
+  else:
+    PageBuffers.init(pageSize, maxBufferedBytes)
+
+func trackWrittenToEnd*(buffers: PageBuffers) {.deprecated: "commit".} =
+  if buffers != nil and buffers.queue.len > 0:
+    buffers.commit(buffers.queue.peekLast.capacity())
+
+func trackWrittenTo*(buffers: PageBuffers, spanHeadPos: ptr byte) {.deprecated: "commit".} =
+  # Compatibility hack relying on commit ignoring `endAddr` for now
+  if buffers != nil and spanHeadPos != nil:
+    buffers.commit(PageSpan(startAddr: spanHeadPos))
+
+template allocWritablePage*(pageSize: Natural, writtenToParam: Natural = 0): auto {.deprecated: "PageRef.init".} =
+  PageRef(data: allocRef newSeqUninit[byte](pageSize),
+          writtenTo: writtenToParam)
+
+func addWritablePage*(buffers: PageBuffers, pageSize: Natural): PageRef {.deprecated: "prepare".} =
+  trackWrittenToEnd(buffers)
+  result = allocWritablePage(pageSize)
+  buffers.queue.addLast result
+
+func getWritablePage*(buffers: PageBuffers,
+                      preferredSize: Natural): PageRef {.deprecated: "prepare".} =
+  if buffers.queue.len > 0:
+    let lastPage = buffers.queue.peekLast
+    if lastPage.writtenTo < lastPage.data[].len:
+      return lastPage
+
+  return addWritablePage(buffers, preferredSize)
+
+func addWritablePage*(buffers: PageBuffers): PageRef {.deprecated: "prepare".} =
+  buffers.addWritablePage(buffers.pageSize)
+
+template getWritableSpan*(buffers: PageBuffers): PageSpan {.deprecated: "prepare".} =
+  let page = getWritablePage(buffers, buffers.pageSize)
+  writableSpan(page)
+
+func appendUnbufferedWrite*(buffers: PageBuffers,
+                            src: pointer, srcLen: Natural) {.deprecated: "write".} =
+  if srcLen > 0:
+    buffers.write(makeOpenArray(cast[ptr byte](src), srcLen))
 
 func ensureRunway*(buffers: PageBuffers,
                    currentHeadPos: var PageSpan,
-                   neededRunway: Natural) =
+                   neededRunway: Natural) {.deprecated: "prepare".} =
   # End writing to the current buffer (if any) and create a new one of the given
   # length
+  if currentHeadPos.startAddr != nil:
+    buffers.commit(currentHeadPos)
+  currentHeadPos = buffers.prepare(neededRunway)
+
   let page =
     if currentHeadPos.startAddr == nil:
       # This is a brand new stream, just like we recomend.
@@ -247,11 +581,11 @@ func ensureRunway*(buffers: PageBuffers,
 template len*(buffers: PageBuffers): Natural =
   buffers.queue.len
 
-func totalBufferedBytes*(buffers: PageBuffers): Natural =
+func totalBufferedBytes*(buffers: PageBuffers): Natural {.deprecated: "consumable".} =
   for i in 0 ..< buffers.queue.len:
     result += buffers.queue[i].pageLen
 
-func canAcceptWrite*(buffers: PageBuffers, writeSize: Natural): bool =
+func canAcceptWrite*(buffers: PageBuffers, writeSize: Natural): bool {.deprecated: "Unimplemented".} =
   true or # TODO Remove this line
   buffers.queue.len == 0 or
   buffers.maxBufferedBytes == 0 or
@@ -263,7 +597,7 @@ template popFirst*(buffers: PageBuffers): PageRef =
 template `[]`*(buffers: PageBuffers, idx: Natural): PageRef =
   buffers.queue[idx]
 
-func splitLastPageAt*(buffers: PageBuffers, address: ptr byte) =
+func splitLastPageAt*(buffers: PageBuffers, address: ptr byte) {.deprecated: "reserve".} =
   var
     topPage = buffers.queue.peekLast
     splitPosition = distance(topPage.allocationStart, address)
@@ -281,13 +615,13 @@ iterator consumePages*(buffers: PageBuffers): PageRef =
   var recycledPage: PageRef
   while buffers.queue.len > 0:
     var page = peekFirst(buffers.queue)
+    if page.len > 0:
+      # TODO: what if the body throws an exception?
+      # Should we do anything with the consumed page?
+      yield page
 
-    # TODO: what if the body throws an exception?
-    # Should we do anything with the consumed page?
-    yield page
-
-    if page.data[].len == buffers.pageSize:
-      recycledPage = page
+      if page.data[].len == buffers.pageSize:
+        recycledPage = page
 
     discard buffers.queue.popFirst
 
@@ -301,27 +635,7 @@ iterator consumePageBuffers*(buffers: PageBuffers): (ptr byte, Natural) =
     yield (page.readableStart,
            Natural(page.writtenTo - page.consumedTo))
 
-# BEWARE! These templates violate the double evaluation
-#         safety measures in order to produce better inlined
-#         code. We are using a `var` type to make it harder
-#         to accidentally misuse them.
-template len*(span: var PageSpan): Natural =
-  distance(span.startAddr, span.endAddr)
-
-template atEnd*(span: var PageSpan): bool =
-  span.startAddr == span.endAddr
-
-template hasRunway*(span: var PageSpan): bool =
-  span.startAddr != span.endAddr
-
-template bumpPointer*(span: var PageSpan, numberOfBytes: Natural = 1) =
-  span.startAddr = offset(span.startAddr, numberOfBytes)
-
-template writeByte*(span: var PageSpan, val: byte) =
-  span.startAddr[] = val
-  span.startAddr = offset(span.startAddr, 1)
-
-template charsToBytes*(chars: openArray[char]): untyped =
+template charsToBytes*(chars: openArray[char]): untyped {.deprecated: "multiple evaluation!".} =
   chars.toOpenArrayByte(0, chars.len - 1)
 
 type
@@ -346,21 +660,19 @@ template implementSingleRead*(buffersParam: PageBuffers,
   if readStartVar != nil:
     bytesRead = readBlock
   else:
-    let
-      bestPageSize = nextAlignedSize(readLenVar, buffers.pageSize)
-      page = getWritablePage(buffers, bestPageSize)
+    var span = buffers.prepare(buffers.nextAlignedSize(readLenVar))
 
-    readStartVar = writableStart(page)
-    readLenVar = page.data[].len - page.writtenTo
+    readStartVar = span.startAddr
+    readLenVar = span.len
 
-    # TODO: what if we exit with an exception here?
-    # Are the side-effects of `getWritablePage` above OK to keep?
+    # readBlock may raise meaning that the prepared span might be get recycled
+    # in a future read, even if readBlock wrote some data in it - we have no
+    # way of knowing how much though!
     bytesRead = readBlock
-    page.writtenTo += bytesRead
+    buffers.commit(bytesRead)
 
   if (bytesRead == 0 and zeroReadIsNotEof notin flags) or
      (partialReadIsEof in flags and bytesRead < readLenVar):
     buffers.eofReached = true
 
   bytesRead
-

--- a/faststreams/pipelines.nim
+++ b/faststreams/pipelines.nim
@@ -35,7 +35,7 @@ when fsAsyncSupport:
     if buffers.eofReached: return 0
 
     var
-      bytesInBuffersAtStart = buffers.totalBufferedBytes
+      bytesInBuffersAtStart = buffers.consumable()
       minBytesExpected = max(1, dstLen)
       bytesInBuffersNow = bytesInBuffersAtStart
 
@@ -43,7 +43,7 @@ when fsAsyncSupport:
       awake buffers.waitingWriter
       buffers.waitingReader.enterWait "waiting for writer to buffer more data"
 
-      bytesInBuffersNow = buffers.totalBufferedBytes
+      bytesInBuffersNow = buffers.consumable()
       if buffers.eofReached:
         return bytesInBuffersNow - bytesInBuffersAtStart
 

--- a/faststreams/textio.nim
+++ b/faststreams/textio.nim
@@ -121,7 +121,7 @@ proc writeHex*(s: OutputStream, bytes: openArray[byte]) =
     s.write hexChars[int b and 0xF]
 
 proc writeHex*(s: OutputStream, chars: openArray[char]) =
-  writeHex s, charsToBytes(chars)
+  writeHex s, chars.toOpenArrayByte(0, chars.high())
 
 const
   NewLines* = {'\r', '\n'}
@@ -150,7 +150,7 @@ proc readUntil*(s: InputStream,
   fsAssert readableNow(s)
   var res = ""
   while s.readable(sep.len):
-    if s.lookAheadMatch(charsToBytes(sep)):
+    if s.lookAheadMatch(sep.toOpenArrayByte(0, sep.high())):
       return some(res)
     res.add s.read.char
 

--- a/tests/all_tests.nim
+++ b/tests/all_tests.nim
@@ -1,4 +1,5 @@
 import
+  test_buffers,
   test_inputs,
   test_outputs,
   test_pipelines,

--- a/tests/test_buffers.nim
+++ b/tests/test_buffers.nim
@@ -1,0 +1,361 @@
+{.used.}
+
+import unittest2, ../faststreams/buffers
+import std/random
+
+const bytes256 = block:
+  var v: array[256, byte]
+  for i in 0 ..< 256:
+    v[i] = byte i
+  v
+
+proc consumeAll(buf: PageBuffers): seq[byte] =
+  for page in buf.consumePages():
+    result.add page.data()
+
+# Note: these tests count `consume` calls as a way to make sure we don't waste
+# buffers - however, the number of consume calls is not part of the stable API
+# and therefore, tests may have to change in the future
+suite "PageBuffers":
+  test "prepare/commit/consume":
+    let pageSize = 8
+    let buf = PageBuffers.init(8)
+    let input = bytes256[0 .. 31]
+
+    # Write in one go
+    buf.write(input)
+
+    var res: seq[byte]
+
+    var r = buf.consume()
+    res.add r.data()
+    check res == input
+
+    # Buffer should now be empty
+    check buf.consumable() == 0
+
+  test "prepare/commit/consume with partial writes and reads":
+    let pageSize = 8
+    let buf = PageBuffers.init(pageSize)
+    let input = bytes256[0 .. 15] # 16 bytes, 2 pages
+
+    # Write in two steps
+    var w1 = buf.prepare(8)
+    w1.write(input[0 .. 7])
+    buf.commit(8)
+
+    var w2 = buf.prepare(8)
+    w2.write(input[8 .. 15])
+    buf.commit(8)
+
+    # Consume part of first write
+    var r = buf.consume(4)
+    check @(r.data()) == input[0 .. 3]
+
+    r = buf.consume()
+    check @(r.data()) == input[4 .. 7]
+
+    r = buf.consume()
+    check @(r.data()) == input[8 .. 15]
+
+    # Buffer should now be empty
+    check buf.consumable() == 0
+
+  test "reserve/commit/consume blocks until commit":
+    let pageSize = 8
+    let buf = PageBuffers.init(pageSize)
+    let input = bytes256[0 .. 7]
+
+    var w = buf.reserve(8)
+    w.write(input)
+    # Not committed yet, should not be readable
+    check buf.consumable() == 0
+
+    buf.commit(w)
+    # Now it should be readable
+    var r = buf.consume()
+    check @(r.data()) == input
+
+  test "reserve/prepare/commit/consume interleaved":
+    let pageSize = 8
+    let buf = PageBuffers.init(pageSize)
+    let a = bytes256[0 .. 7]
+    let b = bytes256[8 .. 15]
+
+    var w1 = buf.reserve(8)
+    w1.write(a)
+    var w2 = buf.prepare(8)
+    w2.write(b)
+    buf.commit(w2)
+    # Only b is committed, but a is reserved and not yet committed, so nothing is readable
+    check buf.consumable() == 0
+
+    buf.commit(w1)
+
+    # Now both a and b should be readable, in order
+    var r = buf.consume()
+    check @(r.data()) == a
+    r = buf.consume()
+    check @(r.data()) == b
+    check buf.consumable() == 0
+
+  test "multiple small writes and reads, crossing page boundaries":
+    let pageSize = 4
+    let buf = PageBuffers.init(pageSize)
+    let input = bytes256[0 .. 11] # 12 bytes, 3 pages
+
+    # Write 3 times, 4 bytes each
+    for i in 0 .. 2:
+      var w = buf.prepare(4)
+      w.write(input[(i * 4) ..< (i * 4 + 4)])
+      buf.commit(4)
+
+    # Read 6 times, 2 bytes each
+    var res: seq[byte]
+    for i in 0 .. 5:
+      var r = buf.consume(2)
+      res.add r.data()
+    check res == input
+
+    # Buffer should now be empty
+    check buf.consumable() == 0
+
+  test "unconsume restores data":
+    let pageSize = 8
+    let buf = PageBuffers.init(pageSize)
+    let input = bytes256[0 .. 7]
+
+    var w = buf.prepare(8)
+    w.write(input)
+    buf.commit(8)
+
+    var r = buf.consume(8)
+    check @(r.data()) == input
+
+    # Unconsume 4 bytes
+    buf.unconsume(4)
+    var r2 = buf.consume(4)
+    check @(r2.data()) == input[4 .. 7]
+
+    # Buffer should now be empty
+    check buf.consumable() == 0
+
+  test "prepare with more than page size allocates larger page":
+    let pageSize = 8
+    let buf = PageBuffers.init(pageSize)
+    let input = bytes256[0 .. 15] # 16 bytes
+
+    var w = buf.prepare(16)
+    w.write(input)
+    buf.commit(16)
+
+    var r = buf.consume(16)
+    check @(r.data()) == input
+
+  test "reserve with more than page size allocates larger page":
+    let pageSize = 8
+    let buf = PageBuffers.init(pageSize)
+    let input = bytes256[0 .. 15] # 16 bytes
+
+    var w = buf.reserve(16)
+    w.write(input)
+    buf.commit(w)
+
+    var r = buf.consume(16)
+    check @(r.data()) == input
+
+  test "mix of prepare, reserve, commit, and consume with random order":
+    let pageSize = 8
+    let buf = PageBuffers.init(pageSize)
+    var expected: seq[byte]
+    var written: seq[(string, seq[byte], PageSpan)]
+    randomize(1000)
+
+    # Randomly choose prepare or reserve, then commit in random order
+    for i in 0 .. 3:
+      let d = bytes256[(i * 8) ..< (i * 8 + 8)]
+      if rand(1) == 0:
+        var w = buf.prepare(8)
+        w.write(d)
+        written.add(("prepare", d, w))
+        buf.commit(8)
+      else:
+        var w = buf.reserve(8)
+        w.write(d)
+        written.add(("reserve", d, w))
+
+    # Commit in random order
+    var idxs = @[0, 1, 2, 3]
+    idxs.shuffle()
+    for i in idxs:
+      let (kind, d, w) = written[i]
+      if kind == "reserve":
+        buf.commit(w)
+
+    # All data should be readable in original order
+    for i in 0 .. 3:
+      expected.add(bytes256[(i * 8) ..< (i * 8 + 8)])
+    check consumeAll(buf) == expected
+
+  test "consumePages iterator yields all data and recycles last page":
+    let pageSize = 8
+    let buf = PageBuffers.init(pageSize)
+    let input = bytes256[0 .. 23] # 24 bytes, 3 pages
+
+    for i in 0 .. 2:
+      var w = buf.prepare()
+      w.write(input[i * 8 ..< ((i + 1) * 8)])
+      buf.commit(w)
+
+    var seen: seq[byte]
+    for page in buf.consumePages():
+      seen.add page.data()
+
+    check seen == input
+    # After consuming, the buffer should have one recycled page
+    check buf.queue.len == 1
+    check buf.queue.peekLast.consumedTo == 0
+    check buf.queue.peekLast.writtenTo == 0
+
+  test "consumePageBuffers yields correct pointers and lengths":
+    let buf = PageBuffers.init(8)
+    let input = bytes256[0 .. 15] # 16 bytes, 2 pages
+
+    var w = buf.prepare()
+    w.write(input[0 .. 7])
+    buf.commit(w)
+    w = buf.prepare()
+    w.write(input[8 .. 15])
+    buf.commit(w)
+
+    var seen: seq[byte]
+    for (p, len) in buf.consumePageBuffers():
+      let s = cast[ptr UncheckedArray[byte]](p)
+      for i in 0 ..< int(len):
+        seen.add s[i]
+    check seen == input
+
+  test "commit less than prepared within a single page":
+    let pageSize = 8
+    let buf = PageBuffers.init(pageSize)
+    let input = bytes256[0 .. 7]
+
+    var w = buf.prepare(8)
+    w.write(input)
+    # Only commit 4 bytes
+    buf.commit(4)
+
+    var r = buf.consume()
+    check @(r.data()) == input[0 .. 3]
+    # The rest should not be available
+    check buf.consumable() == 0
+
+    # To write more, must call prepare again
+    var w2 = buf.prepare(4)
+    w2.write(input[4 .. 7])
+    buf.commit(4)
+    r = buf.consume()
+    check @(r.data()) == input[4 .. 7]
+    check buf.consumable() == 0
+
+  test "commit less than reserved, then reserve again in same page":
+    let pageSize = 8
+    let buf = PageBuffers.init(pageSize)
+    let input = bytes256[0 .. 7]
+
+    var w = buf.reserve(8)
+    w.write(input[0 .. 3])
+    # Commit only 4 bytes
+    buf.commit(w)
+    # The committed reserve should be available also
+    check buf.consumable() == 4
+
+    var w2 = buf.reserve(4)
+    w2.write(input[4 .. 7])
+    buf.commit(w2)
+
+    var r = buf.consume()
+    check @(r.data()) == input[0 .. 3]
+    r = buf.consume()
+    check @(r.data()) == input[4 .. 7]
+    check buf.consumable() == 0
+
+  test "commit less than prepared, crossing page boundary":
+    let pageSize = 8
+    let buf = PageBuffers.init(pageSize)
+    let input = bytes256[0 .. 15] # 16 bytes, 2 writes
+
+    var w = buf.prepare(16)
+    w.write(input)
+    buf.commit(10)
+
+    var r = buf.consume()
+    check @(r.data()) == input[0 .. 9]
+    # The rest should not be available
+    check buf.consumable() == 0
+
+    # To write more, must call prepare again
+    var w2 = buf.prepare(6)
+    w2.write(input[10 .. 15])
+    buf.commit(6)
+    r = buf.consume()
+    check @(r.data()) == input[10 .. 15]
+    check buf.consumable() == 0
+
+  test "commit less than reserved, crossing page boundary, then reserve again":
+    let pageSize = 8
+    let buf = PageBuffers.init(pageSize)
+    let input = bytes256[0 .. 15] # 16 bytes
+
+    var w = buf.reserve(16)
+    w.write(input[0 .. 9])
+    # Commit only first 10 bytes
+    buf.commit(w)
+    check buf.consumable() == 10
+
+    # Must reserve again
+    var w2 = buf.reserve(6)
+    w2.write(input[10 .. 15])
+    buf.commit(w2)
+    var r = buf.consume()
+    check @(r.data()) == input[0 .. 9]
+    r = buf.consume()
+    check @(r.data()) == input[10 .. 15]
+    check buf.consumable() == 0
+
+  test "commit less than prepared/reserved, then interleave with new writes":
+    let pageSize = 8
+    let buf = PageBuffers.init(pageSize)
+    let a = bytes256[0 .. 7]
+    let b = bytes256[8 .. 15]
+
+    # Prepare 8, commit 4
+    var w1 = buf.prepare(8)
+    w1.write(a)
+    buf.commit(4)
+
+    # Must prepare again
+    var w1b = buf.prepare(4)
+    w1b.write(a[4 .. 7])
+    buf.commit(4)
+
+    # Reserve 8, commit 4
+    var w2 = buf.reserve(8)
+    w2.write(b[0 .. 3])
+    buf.commit(w2)
+
+    check buf.consumable() == 12
+
+    # Must reserve again
+    var w2b = buf.reserve(4)
+    w2b.write(b[4 .. 7])
+    buf.commit(w2b)
+
+    # All data should be readable in order
+    var r = buf.consume()
+    check @(r.data()) == a
+    r = buf.consume()
+    check @(r.data()) == b[0 .. 3]
+    r = buf.consume()
+    check @(r.data()) == b[4 .. 7]
+    check buf.consumable() == 0


### PR DESCRIPTION
Reimplement `PageBuffers` primtives simplify its usage in streams. In particular, buffers now follow the established
`prepare`/`commit`/`consume` pattern for streaming also seen in chronos and asio.

In short, each time a buffer is needed, `prepare` is called to allocate an appropriate buffer - once the data has been written, `commit` notifies the buffer of how many bytes were actually written. Subsequently, `consume` gives a reader access to the committed bytes.

In addition to `prepare`, `reserve` can be used for delayed-write patterns, moving the tracking of both variable-sized and fixed-size delayed writes directly into PageBuffers.

This is the first round of cleanups that aims to address bugs and issues with how delayed writes are tracked, as well as reduce the complexity of the implementation while maintaining its performance profile.

With this change, `PageBuffers` becomes usable as a general-purpose paged buffer outside of its usage in faststreams.

* refactor primitive buffer operations into prepare/commit/consume
* document PageBuffers
* deprecate most of the old PageBuffers API - will be removed at some point in the near future
* move reservation logic from OutputStream to PageBuffers, fixing several bugs in the process - both fixed and variable-sized reservations now use the same logic simplifying the implementation
* introduce post-factum buffer overrun checks for PageSpan when switching spans
* delay the allocation of new pages after flush such that if no write happens, no page is allocated