### PR TITLE
add `sink` overload for memory input

### DIFF
--- a/faststreams/inputs.nim
+++ b/faststreams/inputs.nim
@@ -493,7 +493,7 @@ func unsafeMemoryInput*(mem: openArray[byte]): InputStreamHandle =
         endAddr: offset(head, mem.len)),
       spanEndPos: mem.len)
 
-func unsafeMemoryInput*(str: string): InputStreamHandle =
+func unsafeMemoryInput*(str: openArray[char]): InputStreamHandle =
   unsafeMemoryInput str.toOpenArrayByte(0, str.len - 1)
 
 proc len(s: VmInputStream): Option[Natural] =
@@ -518,22 +518,34 @@ when fsAsyncSupport:
 func memoryInput*(buffers: PageBuffers): InputStreamHandle =
   makeHandle InputStream(buffers: buffers)
 
-func memoryInput*(data: openArray[byte]): InputStreamHandle =
+func memoryInput*(data: sink seq[byte]): InputStreamHandle =
   when nimvm:
-    makeHandle VmInputStream(data: @data, pos: 0)
+    makeHandle VmInputStream(data: move(data), pos: 0)
   else:
-    let stream = if data.len > 0:
-      let buffers = PageBuffers.init(data.len)
-      buffers.write(data)
+    let
+      len = data.len
+      stream =
+        if len > 0:
+          let store = new seq[byte]
+          store[] = move(data)
 
-      InputStream(buffers: buffers)
-    else:
-      InputStream()
+          let page = PageRef.init(store, 0)
+          page.commit(len)
+
+          let buffers = PageBuffers.init(len)
+          buffers.queue.addLast page
+
+          InputStream(buffers: buffers)
+        else:
+          InputStream()
 
     makeHandle stream
 
+func memoryInput*(data: openArray[byte]): InputStreamHandle =
+  memoryInput(@data)
+
 func memoryInput*(data: openArray[char]): InputStreamHandle =
-  memoryInput data.toOpenArrayByte(0, data.high())
+  memoryInput(@data.toOpenArrayByte(0, data.high()))
 
 func resetBuffers*(s: InputStream, buffers: PageBuffers) =
   # This should be used only on safe memory input streams


### PR DESCRIPTION
In many cases where a temporary `seq` is involved, this is no less efficient than `unsafeMemoryInput` but certainly more safe.

Unfortunately, this convenience cannot easily be extended to `write` and friends due to the lack of [sink
overloading](https://github.com/nim-lang/Nim/issues/25081).